### PR TITLE
店舗登録機能追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,9 @@ gem 'jquery-rails'
 # 環境変数を使用できる
 gem 'dotenv-rails'
 
+# デバックツールを使用できる
+gem 'pry-rails'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,6 +71,7 @@ GEM
     chromedriver-helper (2.1.1)
       archive-zip (~> 0.10)
       nokogiri (~> 1.8)
+    coderay (1.1.3)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -127,6 +128,11 @@ GEM
       racc (~> 1.4)
     orm_adapter (0.5.0)
     popper_js (1.16.0)
+    pry (0.14.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     public_suffix (4.0.6)
     puma (3.12.6)
     racc (1.5.2)
@@ -239,6 +245,7 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   jquery-rails
   listen (>= 3.0.5, < 3.2)
+  pry-rails
   puma (~> 3.11)
   rails (= 5.2.4.2)
   sass-rails (~> 5.0)

--- a/app/assets/javascripts/coffee_shops.coffee
+++ b/app/assets/javascripts/coffee_shops.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/coffee_shops.scss
+++ b/app/assets/stylesheets/coffee_shops.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Coffee_shops controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/coffee_shops_controller.rb
+++ b/app/controllers/coffee_shops_controller.rb
@@ -1,0 +1,22 @@
+class CoffeeShopsController < ApplicationController
+  def index
+  end
+
+  def show
+  end
+
+  def new
+  end
+
+  def create
+  end
+
+  def edit
+  end
+
+  def update
+  end
+
+  def destroy
+  end
+end

--- a/app/controllers/coffee_shops_controller.rb
+++ b/app/controllers/coffee_shops_controller.rb
@@ -11,6 +11,9 @@ class CoffeeShopsController < ApplicationController
   end
 
   def create
+    @coffee_shop = CoffeeShop.new(coffee_shop_params)
+    @coffee_shop.save
+    redirect_to coffee_shop_url @coffee_shop
   end
 
   def edit
@@ -21,4 +24,9 @@ class CoffeeShopsController < ApplicationController
 
   def destroy
   end
+  
+  private
+    def coffee_shop_params
+      params.require(:coffee_shop).permit(:name, :shop_url, :address, :tell, :access, :business_start_hour, :business_end_hour, :regular_holiday, :instagram_url, :instagram_spot_url, :municipalitie_id, :first_image_url, :second_image_url, :third_image_url)
+    end
 end

--- a/app/controllers/coffee_shops_controller.rb
+++ b/app/controllers/coffee_shops_controller.rb
@@ -28,6 +28,9 @@ class CoffeeShopsController < ApplicationController
   end
 
   def destroy
+    @coffee_shop = CoffeeShop.find(params[:id])
+    @coffee_shop.destroy
+    redirect_to coffee_shops_path
   end
   
   private

--- a/app/controllers/coffee_shops_controller.rb
+++ b/app/controllers/coffee_shops_controller.rb
@@ -18,9 +18,13 @@ class CoffeeShopsController < ApplicationController
   end
 
   def edit
+    @coffee_shop = CoffeeShop.find(params[:id])
   end
 
   def update
+    @coffee_shop = CoffeeShop.find(params[:id])
+    @coffee_shop.update(coffee_shop_params)
+    redirect_to coffee_shop_url @coffee_shop
   end
 
   def destroy

--- a/app/controllers/coffee_shops_controller.rb
+++ b/app/controllers/coffee_shops_controller.rb
@@ -7,6 +7,7 @@ class CoffeeShopsController < ApplicationController
   end
 
   def new
+    @coffee_shop = CoffeeShop.new
   end
 
   def create

--- a/app/controllers/coffee_shops_controller.rb
+++ b/app/controllers/coffee_shops_controller.rb
@@ -4,6 +4,7 @@ class CoffeeShopsController < ApplicationController
   end
 
   def show
+    @coffee_shop = CoffeeShop.find(params[:id])
   end
 
   def new

--- a/app/controllers/coffee_shops_controller.rb
+++ b/app/controllers/coffee_shops_controller.rb
@@ -15,6 +15,12 @@ class CoffeeShopsController < ApplicationController
     @coffee_shop = CoffeeShop.new(coffee_shop_params)
     @coffee_shop.save
     redirect_to coffee_shop_url @coffee_shop
+    # バリデーションエラーでメッセージを出したい
+    # if @coffee_shop.save
+    #   redirect_to coffee_shop_url @coffee_shop
+    # else
+    #   render @coffee_shop.new
+    # end
   end
 
   def edit

--- a/app/controllers/coffee_shops_controller.rb
+++ b/app/controllers/coffee_shops_controller.rb
@@ -1,5 +1,6 @@
 class CoffeeShopsController < ApplicationController
   def index
+    @coffee_shops = CoffeeShop.all
   end
 
   def show

--- a/app/helpers/coffee_shops_helper.rb
+++ b/app/helpers/coffee_shops_helper.rb
@@ -1,0 +1,2 @@
+module CoffeeShopsHelper
+end

--- a/app/models/coffee_shop.rb
+++ b/app/models/coffee_shop.rb
@@ -1,0 +1,2 @@
+class CoffeeShop < ApplicationRecord
+end

--- a/app/models/coffee_shop.rb
+++ b/app/models/coffee_shop.rb
@@ -1,2 +1,35 @@
 class CoffeeShop < ApplicationRecord
+	# バリデーション
+	# 必ず登録してほしい項目
+	validates :name, :address, :tell, presence: true
+	
+	# 重複チェック
+	validates :shop_url, :tell, uniqueness: true
+	
+	# 電話番号チェック
+	validates :tell, format: { with: /\A\d{10,11}\z/ }
+	validates :tell, numericality: true
+	
+	# URLチェック
+	validates :shop_url, :instagram_url, :instagram_spot_url, format: /\A#{URI::regexp(%w(http https))}\z/
+	
+	# 時間チェック
+	# validates　:business_start_hour, :business_end_hour,
+	
+	# 文字数
+	validates :name, length: { maximum: 30}
+	validates :shop_url, length: { maximum: 100}
+	validates :address, length: { maximum: 100}
+	validates :tell, length: { maximum: 11}
+	validates :access, length: { maximum: 100}
+	validates :business_start_hour, length: { maximum: 6}
+	validates :business_end_hour, length: { maximum: 6}
+	validates :regular_holiday, length: { maximum: 14}
+	validates :instagram_url, length: { maximum: 100}
+	validates :instagram_spot_url, length: { maximum: 100}
+	validates :municipalitie_id, length: { maximum: 100}
+	validates :first_image_url, length: { maximum: 100}
+	validates :second_image_url, length: { maximum: 100}
+	validates :third_image_url, length: { maximum: 100}
+	
 end

--- a/app/models/coffee_shop.rb
+++ b/app/models/coffee_shop.rb
@@ -4,32 +4,29 @@ class CoffeeShop < ApplicationRecord
 	validates :name, :address, :tell, presence: true
 	
 	# 重複チェック
-	validates :shop_url, :tell, uniqueness: true
+	validates :tell, uniqueness: true
 	
 	# 電話番号チェック
 	validates :tell, format: { with: /\A\d{10,11}\z/ }
 	validates :tell, numericality: true
-	
-	# URLチェック
-	validates :shop_url, :instagram_url, :instagram_spot_url, format: /\A#{URI::regexp(%w(http https))}\z/
 	
 	# 時間チェック
 	# validates　:business_start_hour, :business_end_hour,
 	
 	# 文字数
 	validates :name, length: { maximum: 30}
-	validates :shop_url, length: { maximum: 100}
-	validates :address, length: { maximum: 100}
+	validates :shop_url, length: { maximum: 2048}
+	validates :address, length: { maximum: 300}
 	validates :tell, length: { maximum: 11}
 	validates :access, length: { maximum: 100}
 	validates :business_start_hour, length: { maximum: 6}
 	validates :business_end_hour, length: { maximum: 6}
 	validates :regular_holiday, length: { maximum: 14}
-	validates :instagram_url, length: { maximum: 100}
-	validates :instagram_spot_url, length: { maximum: 100}
-	validates :municipalitie_id, length: { maximum: 100}
-	validates :first_image_url, length: { maximum: 100}
-	validates :second_image_url, length: { maximum: 100}
-	validates :third_image_url, length: { maximum: 100}
+	validates :instagram_url, length: { maximum: 2048}
+	validates :instagram_spot_url, length: { maximum: 2048}
+	validates :municipalitie_id, length: { maximum: 1000}
+	validates :first_image_url, length: { maximum: 2048}
+	validates :second_image_url, length: { maximum: 2048}
+	validates :third_image_url, length: { maximum: 2048}
 	
 end

--- a/app/views/coffee_shops/create.html.erb
+++ b/app/views/coffee_shops/create.html.erb
@@ -1,0 +1,2 @@
+<h1>CoffeeShops#create</h1>
+<p>Find me in app/views/coffee_shops/create.html.erb</p>

--- a/app/views/coffee_shops/destroy.html.erb
+++ b/app/views/coffee_shops/destroy.html.erb
@@ -1,0 +1,2 @@
+<h1>CoffeeShops#destroy</h1>
+<p>Find me in app/views/coffee_shops/destroy.html.erb</p>

--- a/app/views/coffee_shops/edit.html.erb
+++ b/app/views/coffee_shops/edit.html.erb
@@ -9,6 +9,8 @@
   <br>
   電話番号<%= f.number_field :tell %>
   <br>
+  アクセス<%= f.text_field :access %>
+  <br>
   営業開始時間<%= f.time_field :business_start_hour %>
   <br>
   営業終了時間<%= f.time_field :business_end_hour %>
@@ -26,7 +28,7 @@
   画像２<%= f.text_field :second_image_url %>
   <br>
   画像３<%= f.text_field :third_image_url %>
-  
+  <br>
   <%= f.submit "Update" %>
 <% end %>
 

--- a/app/views/coffee_shops/edit.html.erb
+++ b/app/views/coffee_shops/edit.html.erb
@@ -1,0 +1,2 @@
+<h1>CoffeeShops#edit</h1>
+<p>Find me in app/views/coffee_shops/edit.html.erb</p>

--- a/app/views/coffee_shops/edit.html.erb
+++ b/app/views/coffee_shops/edit.html.erb
@@ -1,2 +1,33 @@
 <h1>CoffeeShops#edit</h1>
-<p>Find me in app/views/coffee_shops/edit.html.erb</p>
+
+<%= form_with model: @coffee_shop do |f| %>
+	店舗名<%= f.text_field :name %>
+  <br>
+  店舗HP<%= f.text_field :shop_url %>
+  <br>
+  住所<%= f.text_field :address %>
+  <br>
+  電話番号<%= f.number_field :tell %>
+  <br>
+  営業開始時間<%= f.time_field :business_start_hour %>
+  <br>
+  営業終了時間<%= f.time_field :business_end_hour %>
+  <br>
+  定休日<%= f.text_field :regular_holiday %>
+  <br>
+  Instagram公式URL<%= f.text_field :instagram_url %>
+  <br>
+  InstagramスポットURL<%= f.text_field :instagram_spot_url %>
+  <br>
+  エリアid<%= f.number_field :municipalitie_id %>
+  <br>
+  画像１<%= f.text_field :first_image_url %>
+  <br>
+  画像２<%= f.text_field :second_image_url %>
+  <br>
+  画像３<%= f.text_field :third_image_url %>
+  
+  <%= f.submit "Update" %>
+<% end %>
+
+<%= link_to "Back", coffee_shops_path %>

--- a/app/views/coffee_shops/index.html.erb
+++ b/app/views/coffee_shops/index.html.erb
@@ -1,0 +1,2 @@
+<h1>CoffeeShops#index</h1>
+<p>Find me in app/views/coffee_shops/index.html.erb</p>

--- a/app/views/coffee_shops/index.html.erb
+++ b/app/views/coffee_shops/index.html.erb
@@ -17,6 +17,7 @@
   
   <%= link_to "Show", coffee_shop_path(coffee_shop) %>
   <%= link_to "Edit", edit_coffee_shop_path(coffee_shop) %>
+  <%= link_to "Delete", coffee_shop_path(coffee_shop), method: :delete, data: { confirm: 'Are you sure?' }  %>
   <br>
 <% end %>
 

--- a/app/views/coffee_shops/index.html.erb
+++ b/app/views/coffee_shops/index.html.erb
@@ -1,2 +1,22 @@
 <h1>CoffeeShops#index</h1>
-<p>Find me in app/views/coffee_shops/index.html.erb</p>
+<% @coffee_shops.each do |coffee_shop| %>
+  <%= coffee_shop.name %>
+  <%= coffee_shop.shop_url %>
+  <%= coffee_shop.address %>
+  <%= coffee_shop.tell %>
+  <%= coffee_shop.access %>
+  <%= coffee_shop.business_start_hour %>
+  <%= coffee_shop.business_end_hour %>
+  <%= coffee_shop.regular_holiday %>
+  <%= coffee_shop.instagram_url %>
+  <%= coffee_shop.instagram_spot_url %>
+  <%= coffee_shop.municipalitie_id %>
+  <%= coffee_shop.first_image_url %>
+  <%= coffee_shop.second_image_url %>
+  <%= coffee_shop.third_image_url %>
+  
+  <%= link_to "Show", coffee_shop_path(coffee_shop) %>
+  <%= link_to "Edit", edit_coffee_shop_path(coffee_shop) %>
+<% end %>
+
+<%= link_to "New", new_coffee_shop_path %>

--- a/app/views/coffee_shops/index.html.erb
+++ b/app/views/coffee_shops/index.html.erb
@@ -17,6 +17,7 @@
   
   <%= link_to "Show", coffee_shop_path(coffee_shop) %>
   <%= link_to "Edit", edit_coffee_shop_path(coffee_shop) %>
+  <br>
 <% end %>
 
 <%= link_to "New", new_coffee_shop_path %>

--- a/app/views/coffee_shops/new.html.erb
+++ b/app/views/coffee_shops/new.html.erb
@@ -1,5 +1,8 @@
 <h1>CoffeeShops#new</h1>
+
 <%= form_with model: @coffee_shop do |f| %>
+<!--バリデーションエラーでメッセージを出したい-->
+<!--<%= render 'layouts/error_messages', locals: { coffee_shop: @coffee_shop } %>-->
   店舗名<%= f.text_field :name %>
   <br>
   店舗HP<%= f.text_field :shop_url %>

--- a/app/views/coffee_shops/new.html.erb
+++ b/app/views/coffee_shops/new.html.erb
@@ -1,2 +1,32 @@
 <h1>CoffeeShops#new</h1>
-<p>Find me in app/views/coffee_shops/new.html.erb</p>
+<%= form_with model: @coffee_shop do |f| %>
+  店舗名<%= f.text_field :name %>
+  <br>
+  店舗HP<%= f.text_field :shop_url %>
+  <br>
+  住所<%= f.text_field :address %>
+  <br>
+  電話番号<%= f.number_field :tell %>
+  <br>
+  営業開始時間<%= f.time_field :business_start_hour %>
+  <br>
+  営業終了時間<%= f.time_field :business_end_hour %>
+  <br>
+  定休日<%= f.text_field :regular_holiday %>
+  <br>
+  Instagram公式URL<%= f.text_field :instagram_url %>
+  <br>
+  InstagramスポットURL<%= f.text_field :instagram_spot_url %>
+  <br>
+  エリアid<%= f.number_field :municipalitie_id %>
+  <br>
+  画像１<%= f.text_field :first_image_url %>
+  <br>
+  画像２<%= f.text_field :second_image_url %>
+  <br>
+  画像３<%= f.text_field :third_image_url %>
+  
+  <%= f.submit "Create" %>
+<% end %>
+
+<%= link_to "Back", coffee_shops_path %>

--- a/app/views/coffee_shops/new.html.erb
+++ b/app/views/coffee_shops/new.html.erb
@@ -8,6 +8,8 @@
   <br>
   電話番号<%= f.number_field :tell %>
   <br>
+  アクセス<%= f.text_field :access %>
+  <br>
   営業開始時間<%= f.time_field :business_start_hour %>
   <br>
   営業終了時間<%= f.time_field :business_end_hour %>
@@ -25,7 +27,7 @@
   画像２<%= f.text_field :second_image_url %>
   <br>
   画像３<%= f.text_field :third_image_url %>
-  
+  <br>
   <%= f.submit "Create" %>
 <% end %>
 

--- a/app/views/coffee_shops/new.html.erb
+++ b/app/views/coffee_shops/new.html.erb
@@ -1,0 +1,2 @@
+<h1>CoffeeShops#new</h1>
+<p>Find me in app/views/coffee_shops/new.html.erb</p>

--- a/app/views/coffee_shops/show.html.erb
+++ b/app/views/coffee_shops/show.html.erb
@@ -1,0 +1,2 @@
+<h1>CoffeeShops#show</h1>
+<p>Find me in app/views/coffee_shops/show.html.erb</p>

--- a/app/views/coffee_shops/show.html.erb
+++ b/app/views/coffee_shops/show.html.erb
@@ -1,17 +1,30 @@
 <h1>CoffeeShops#show</h1>
-<%= @coffee_shop.name %>
-<%= @coffee_shop.shop_url %>
-<%= @coffee_shop.address %>
-<%= @coffee_shop.tell %>
-<%= @coffee_shop.access %>
-<%= @coffee_shop.business_start_hour %>
-<%= @coffee_shop.business_end_hour %>
-<%= @coffee_shop.regular_holiday %>
-<%= @coffee_shop.instagram_url %>
-<%= @coffee_shop.instagram_spot_url %>
-<%= @coffee_shop.municipalitie_id %>
-<%= @coffee_shop.first_image_url %>
-<%= @coffee_shop.second_image_url %>
-<%= @coffee_shop.third_image_url %>
-
+  店舗名<%= @coffee_shop.name %>
+  <br>
+  店舗HP<%= @coffee_shop.shop_url %>
+  <br>
+  住所<%= @coffee_shop.address %>
+  <br>
+  電話番号<%= @coffee_shop.tell %>
+  <br>
+  アクセス<%= @coffee_shop.access %>
+  <br>
+  営業開始時間<%= @coffee_shop.business_start_hour %>
+  <br>
+  営業終了時間<%= @coffee_shop.business_end_hour %>
+  <br>
+  定休日<%= @coffee_shop.regular_holiday %>
+  <br>
+  Instagram公式URL<%= @coffee_shop.instagram_url %>
+  <br>
+  InstagramスポットURL<%= @coffee_shop.instagram_spot_url %>
+  <br>
+  エリアid<%= @coffee_shop.municipalitie_id %>
+  <br>
+  画像１<%= @coffee_shop.first_image_url %>
+  <br>
+  画像２<%= @coffee_shop.second_image_url %>
+  <br>
+  画像３<%= @coffee_shop.third_image_url %>
+	<br>
 <%= link_to "Back", coffee_shops_path %>

--- a/app/views/coffee_shops/show.html.erb
+++ b/app/views/coffee_shops/show.html.erb
@@ -1,2 +1,17 @@
 <h1>CoffeeShops#show</h1>
-<p>Find me in app/views/coffee_shops/show.html.erb</p>
+<%= @coffee_shop.name %>
+<%= @coffee_shop.shop_url %>
+<%= @coffee_shop.address %>
+<%= @coffee_shop.tell %>
+<%= @coffee_shop.access %>
+<%= @coffee_shop.business_start_hour %>
+<%= @coffee_shop.business_end_hour %>
+<%= @coffee_shop.regular_holiday %>
+<%= @coffee_shop.instagram_url %>
+<%= @coffee_shop.instagram_spot_url %>
+<%= @coffee_shop.municipalitie_id %>
+<%= @coffee_shop.first_image_url %>
+<%= @coffee_shop.second_image_url %>
+<%= @coffee_shop.third_image_url %>
+
+<%= link_to "Back", coffee_shops_path %>

--- a/app/views/coffee_shops/update.html.erb
+++ b/app/views/coffee_shops/update.html.erb
@@ -1,0 +1,2 @@
+<h1>CoffeeShops#update</h1>
+<p>Find me in app/views/coffee_shops/update.html.erb</p>

--- a/app/views/layouts/_error_messages.html.erb
+++ b/app/views/layouts/_error_messages.html.erb
@@ -1,0 +1,10 @@
+<% if @coffee_shop.errors.any? %>
+  <% binding.pry %>
+  <div class = "alert">
+    <ul>
+      <% @coffee_shop.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,11 @@
 Rails.application.routes.draw do
+  get 'coffee_shops/index'
+  get 'coffee_shops/show'
+  get 'coffee_shops/new'
+  get 'coffee_shops/create'
+  get 'coffee_shops/edit'
+  get 'coffee_shops/update'
+  get 'coffee_shops/destroy'
   devise_for :users, :controllers => {
     :registrations => 'users/registrations',
     :sessions => 'users/sessions',

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,11 +1,6 @@
 Rails.application.routes.draw do
-  get 'coffee_shops/index'
-  get 'coffee_shops/show'
-  get 'coffee_shops/new'
-  get 'coffee_shops/create'
-  get 'coffee_shops/edit'
-  get 'coffee_shops/update'
-  get 'coffee_shops/destroy'
+  resources :coffee_shops
+  
   devise_for :users, :controllers => {
     :registrations => 'users/registrations',
     :sessions => 'users/sessions',

--- a/db/migrate/20211003104233_create_coffee_shops.rb
+++ b/db/migrate/20211003104233_create_coffee_shops.rb
@@ -1,7 +1,21 @@
 class CreateCoffeeShops < ActiveRecord::Migration[5.2]
   def change
     create_table :coffee_shops do |t|
-
+      t.string :name
+      t.string :shop_url
+      t.string :address
+      t.integer :tell
+      t.string :access
+      t.time :business_start_hour
+      t.time :business_end_hour
+      t.string :regular_holiday
+      t.string :instagram_url
+      t.string :instagram_spot_url
+      t.integer :municipalitie_id
+      t.string :first_image_url
+      t.string :second_image_url
+      t.string :third_image_url
+      
       t.timestamps
     end
   end

--- a/db/migrate/20211003104233_create_coffee_shops.rb
+++ b/db/migrate/20211003104233_create_coffee_shops.rb
@@ -1,0 +1,8 @@
+class CreateCoffeeShops < ActiveRecord::Migration[5.2]
+  def change
+    create_table :coffee_shops do |t|
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,26 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_30_132903) do
+ActiveRecord::Schema.define(version: 2021_10_03_104233) do
+
+  create_table "coffee_shops", force: :cascade do |t|
+    t.string "name"
+    t.string "shop_url"
+    t.string "address"
+    t.integer "tell"
+    t.string "access"
+    t.time "business_start_hour"
+    t.time "business_end_hour"
+    t.string "regular_holiday"
+    t.string "instagram_url"
+    t.string "instagram_spot_url"
+    t.integer "municipalitie_id"
+    t.string "first_image_url"
+    t.string "second_image_url"
+    t.string "third_image_url"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "name", null: false

--- a/test/controllers/coffee_shops_controller_test.rb
+++ b/test/controllers/coffee_shops_controller_test.rb
@@ -1,0 +1,39 @@
+require 'test_helper'
+
+class CoffeeShopsControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get coffee_shops_index_url
+    assert_response :success
+  end
+
+  test "should get show" do
+    get coffee_shops_show_url
+    assert_response :success
+  end
+
+  test "should get new" do
+    get coffee_shops_new_url
+    assert_response :success
+  end
+
+  test "should get create" do
+    get coffee_shops_create_url
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get coffee_shops_edit_url
+    assert_response :success
+  end
+
+  test "should get update" do
+    get coffee_shops_update_url
+    assert_response :success
+  end
+
+  test "should get destroy" do
+    get coffee_shops_destroy_url
+    assert_response :success
+  end
+
+end

--- a/test/fixtures/coffee_shops.yml
+++ b/test/fixtures/coffee_shops.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/coffee_shop_test.rb
+++ b/test/models/coffee_shop_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class CoffeeShopTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# 背景
- 店舗の基本情報を登録できるようにする
- 店舗の情報に対してのCRUDを作成する

# やったこと
## コードベース
- 設計方針
- model
  - カフェ以外も今後増える可能性を考慮して`Coffee_shop`で作成
  - バリデーション作成
    - 必須項目`presence`：店舗名、住所、電話番号
    - 重複禁止`uniqueness`： 電話番号
      - 店舗名と住所は同じ場合があるかもしれないので重複禁止には含めない
    - 電話番号チェック`正規表現`：10桁または11桁、数値のみ
    - URLチェック`正規表現`：店舗HPのURL、InstagramのURL、InstagramのスポットURL
    - 最大文字数を制限`length`：店舗名30文字、URL2,048文字、住所300文字

- Cntroller
  - バリデーションに引っかかったとときにメッセージを出すようにしたかったが機能実装できなかったので、他の入力箇所作成ができ次第一緒に機能追加する

- view
  - 全体の機能ができてから編集する

- 備考
  - 検証を行うために、pry-railsを追加
  - https://github.com/pry/pry-rails

## 画面レイアウト
- 一覧画面
![image](https://user-images.githubusercontent.com/87374457/136645546-689fd0bb-77e3-4d99-95f1-38fd605f7893.png)

- 新規登録画面
![image](https://user-images.githubusercontent.com/87374457/136645555-923881dc-bb67-4634-85be-ba64ed72da2d.png)

- 詳細表示画面
![image](https://user-images.githubusercontent.com/87374457/136645572-56f66f74-d38c-44f6-9eec-b58f4ea247a6.png)

- 編集画面
![image](https://user-images.githubusercontent.com/87374457/136645590-a88f94a0-8bea-4775-8427-aa54bedcced0.png)

# 検証内容
- [x] すべての項目の登録が行えるか
- [x] 登録されたデータはすべて一覧画面に表示されているか
- [x] 詳細画面は表示されるか
- [x] 店舗名、住所、電話番号があるときのみ登録ができるか
- [x] 同じ電話番号は登録できないか
- [x] 店舗情報の削除はできるか
- [x] 不正な電話番号の場合、登録処理がされないか

| 電話番後 | 登録 |
| --- | --- |
| 9999999999 | 〇 |
| 99999999999 | 〇 |
| 123456789 | × |
| 123456789123 | × |

- [x] 文字数を超えた場合、登録処理がされないか





