### PR TITLE
店舗名と電話番号を条件の検索機能を実装

### DIFF
--- a/app/controllers/coffee_shops_controller.rb
+++ b/app/controllers/coffee_shops_controller.rb
@@ -39,6 +39,18 @@ class CoffeeShopsController < ApplicationController
     redirect_to coffee_shops_path
   end
   
+  def search
+    # 店舗名　一部一致
+    if params[:name].present?
+      @coffee_shops = CoffeeShop.where('name LIKE ?', "%#{params[:name]}%")
+    # 電話番号　完全一致
+    elsif params[:tell].present?
+      @coffee_shops = CoffeeShop.where(tell: params[:tell])
+    else
+      @coffee_shops = CoffeeShop.none
+    end
+  end
+  
   private
     def coffee_shop_params
       params.require(:coffee_shop).permit(:name, :shop_url, :address, :tell, :access, :business_start_hour, :business_end_hour, :regular_holiday, :instagram_url, :instagram_spot_url, :municipalitie_id, :first_image_url, :second_image_url, :third_image_url)

--- a/app/views/coffee_shops/create.html.erb
+++ b/app/views/coffee_shops/create.html.erb
@@ -1,2 +1,0 @@
-<h1>CoffeeShops#create</h1>
-<p>Find me in app/views/coffee_shops/create.html.erb</p>

--- a/app/views/coffee_shops/destroy.html.erb
+++ b/app/views/coffee_shops/destroy.html.erb
@@ -1,2 +1,0 @@
-<h1>CoffeeShops#destroy</h1>
-<p>Find me in app/views/coffee_shops/destroy.html.erb</p>

--- a/app/views/coffee_shops/search.html.erb
+++ b/app/views/coffee_shops/search.html.erb
@@ -1,0 +1,17 @@
+<h1>検索結果</h1>
+<table>
+  <thead>
+    <tr>
+      <th>
+        Name
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @coffee_shops.each do |coffee_shop| %>
+      <tr>
+        <td><%= coffee_shop.name %><%= link_to "Show", coffee_shop_path(coffee_shop) %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/coffee_shops/search.html.erb
+++ b/app/views/coffee_shops/search.html.erb
@@ -1,17 +1,24 @@
 <h1>検索結果</h1>
-<table>
-  <thead>
-    <tr>
-      <th>
-        Name
-      </th>
-    </tr>
-  </thead>
-  <tbody>
-    <% @coffee_shops.each do |coffee_shop| %>
+<% if @coffee_shops.blank? %>
+  該当店舗なし
+  <br>
+<% else %>
+  <table>
+    <thead>
       <tr>
-        <td><%= coffee_shop.name %><%= link_to "Show", coffee_shop_path(coffee_shop) %></td>
+        <th>
+          Name
+        </th>
       </tr>
-    <% end %>
-  </tbody>
-</table>
+    </thead>
+    <tbody>
+      <% @coffee_shops.each do |coffee_shop| %>
+      
+        <tr>
+          <td><%= coffee_shop.name %><%= link_to "Show", coffee_shop_path(coffee_shop) %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>
+<%= link_to "New", new_coffee_shop_path %>

--- a/app/views/coffee_shops/show.html.erb
+++ b/app/views/coffee_shops/show.html.erb
@@ -27,4 +27,4 @@
   <br>
   画像３<%= @coffee_shop.third_image_url %>
 	<br>
-<%= link_to "Back", coffee_shops_path %>
+<%= link_to "戻る", :back %>

--- a/app/views/coffee_shops/update.html.erb
+++ b/app/views/coffee_shops/update.html.erb
@@ -1,2 +1,0 @@
-<h1>CoffeeShops#update</h1>
-<p>Find me in app/views/coffee_shops/update.html.erb</p>

--- a/app/views/web/index.html.erb
+++ b/app/views/web/index.html.erb
@@ -24,13 +24,16 @@
   <div class="search_by_area">
     (検索のエリア)
     <%= form_with url: search_coffee_shops_path, method: :get, local: true do |f| %>
-      店舗名：
+      店舗名
+      <br>
       <%= f.text_field :name %>
       <%= f.submit :search %>
     <% end %>
+    <hr>
     <%= form_with url: search_coffee_shops_path, method: :get, local: true do |f| %>
-      電話番号：
-      <%= f.text_field :tell %>
+      電話番号検索
+      <br>
+      <%= f.number_field :tell %>
       <%= f.submit :search %>
     <% end %>
   </div>

--- a/app/views/web/index.html.erb
+++ b/app/views/web/index.html.erb
@@ -23,6 +23,16 @@
   
   <div class="search_by_area">
     (検索のエリア)
+    <%= form_with url: search_coffee_shops_path, method: :get, local: true do |f| %>
+      店舗名：
+      <%= f.text_field :name %>
+      <%= f.submit :search %>
+    <% end %>
+    <%= form_with url: search_coffee_shops_path, method: :get, local: true do |f| %>
+      電話番号：
+      <%= f.text_field :tell %>
+      <%= f.submit :search %>
+    <% end %>
   </div>
   
   <hr>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
-  resources :coffee_shops
+  resources :coffee_shops do
+    get :search, on: :collection
+  end
   
   devise_for :users, :controllers => {
     :registrations => 'users/registrations',
@@ -16,7 +18,5 @@ Rails.application.routes.draw do
     get "login", :to => "users/sessions#new"
     delete "logout", :to => "users/sessions#destroy"
   end
-  
-  resources :products
   
 end


### PR DESCRIPTION
# 背景
- この機能が必要な理由
ユーザーが店舗を見つけるため
知っている店舗を検索するときに使用する
- どういった機能か
トップページの検索機能の一部
お店の基本情報をもとに検索する機能
検索結果は別画面に一覧で表示する
-参考にしたWEBページ
[https://techacademy.jp/magazine/22330](https://techacademy.jp/magazine/22330) 
- なぜこのPR単位なのか
店舗名と電話番号は店舗の基本情報から検索する機能だから

# やったこと
- 設計方針
トップページから検索し、検索結果が表示される。
検索結果から該当の店舗詳細を表示できる

 - model
   - 変更なし

 - controler
   - `search`を追加
入力された店舗名または電話番号から店舗を検索する
該当店舗がなければ、空配列を返す

 - view
   - 検索結果画面を作成
電話番号から検索した場合は、必ず1店舗しか表示されないため、
検査結果画面を表示させずに店舗詳細画面を表示させたい 
   - 店舗紹介画面の戻るを一覧表示に行くのではなく、前ページに戻る動作に変更
検索結果から店舗詳細を表示した場合に、検索結果に戻れなかったから
   - 検索結果がからだった場合
空配列か判定したかったので、条件式はblankを使用
参考にしたWEBサイト
[https://qiita.com/go_d_eye_0505/items/541110cb9821734b0623](https://qiita.com/go_d_eye_0505/items/541110cb9821734b0623) 

 # 画面レイアウト
 - 検索画面
![image](https://user-images.githubusercontent.com/87374457/136685802-b25b1a6a-7df0-4fe9-a2ea-b6e03501f704.png)

 - 検索結果画面
![image](https://user-images.githubusercontent.com/87374457/136685833-29ea2bd2-7a58-4278-a93c-95dc1feead91.png)

 # 検証内容
- [x] 店舗名検索ができるか

 | 検索条件 | 検索結果 |
 | --- | --- |
 | test | 〇 |
 | テスト | × |
 | 未入力 | × |

 - [x] 電話番号検索ができるか

 | 検索条件 | 検索結果 |
 | --- | --- |
 | 9999999999 | 〇 |
 | 999999999 | × |
 | 未入力 | × |

 - [x] 戻るボタンで検索結果に戻れるか