### PR TITLE
検索用のカテゴリを追加

### DIFF
--- a/app/assets/javascripts/dashboard/search_categories.coffee
+++ b/app/assets/javascripts/dashboard/search_categories.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/dashboard/search_categories.scss
+++ b/app/assets/stylesheets/dashboard/search_categories.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the dashboard/search_categories controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/dashboard/coffee_shops_controller.rb
+++ b/app/controllers/dashboard/coffee_shops_controller.rb
@@ -18,6 +18,7 @@ class Dashboard::CoffeeShopsController < ApplicationController
 
   def new
     @coffee_shop = CoffeeShop.new
+    @search_categories = SearchCategory.all
   end
 
   def create
@@ -53,6 +54,6 @@ class Dashboard::CoffeeShopsController < ApplicationController
     end
     
     def coffee_shop_params
-      params.require(:coffee_shop).permit(:name, :shop_url, :address, :tell, :access, :business_start_hour, :business_end_hour, :regular_holiday, :instagram_url, :instagram_spot_url, :municipalitie_id, :first_image_url, :second_image_url, :third_image_url)
+      params.require(:coffee_shop).permit(:name, :shop_url, :address, :tell, :access, :business_start_hour, :business_end_hour, :regular_holiday, :instagram_url, :instagram_spot_url, :municipalitie_id, :first_image_url, :second_image_url, :third_image_url, { :search_category_ids => [ ]})
     end
 end

--- a/app/controllers/dashboard/search_categories_controller.rb
+++ b/app/controllers/dashboard/search_categories_controller.rb
@@ -1,0 +1,37 @@
+class Dashboard::SearchCategoriesController < ApplicationController
+  before_action :set_search_category, only: %w[show edit update destroy]
+  layout "dashboard/dashboard"
+  
+  def index
+    @search_categories = SearchCategory.all
+    @search_category = SearchCategory.new
+  end
+  
+  def show
+  end
+  
+  def create
+    @search_category = SearchCategory.new(search_category_params)
+    @search_category.save
+    redirect_to dashboard_search_categories_path
+  end
+  
+  def edit
+  end
+  
+  def update
+    @search_category.update(search_category_params)
+    @search_category.save
+    redirect_to dashboard_search_categories_path
+  end
+  
+  private
+  
+  def set_search_category
+    @search_category = SearchCategory.find(params[:id])
+  end
+  
+  def search_category_params
+    params.require(:search_category).permit(:name)
+  end
+end

--- a/app/controllers/dashboard/search_categories_controller.rb
+++ b/app/controllers/dashboard/search_categories_controller.rb
@@ -25,6 +25,11 @@ class Dashboard::SearchCategoriesController < ApplicationController
     redirect_to dashboard_search_categories_path
   end
   
+  def destroy
+    @search_category.destroy
+    redirect_to dashboard_search_categories_path
+  end
+  
   private
   
   def set_search_category

--- a/app/helpers/dashboard/search_categories_helper.rb
+++ b/app/helpers/dashboard/search_categories_helper.rb
@@ -1,0 +1,2 @@
+module Dashboard::SearchCategoriesHelper
+end

--- a/app/models/coffee_shop.rb
+++ b/app/models/coffee_shop.rb
@@ -1,4 +1,9 @@
 class CoffeeShop < ApplicationRecord
+	has_many :coffee_shop_search_categories, dependent: :destroy
+	has_many :search_categories, :through => :coffee_shop_search_categories
+	
+	accepts_nested_attributes_for :coffee_shop_search_categories, allow_destroy: true
+	
 	# バリデーション
 	# 必ず登録してほしい項目
 	validates :name, :address, :tell, presence: true

--- a/app/models/coffee_shop_search_category.rb
+++ b/app/models/coffee_shop_search_category.rb
@@ -1,2 +1,4 @@
 class CoffeeShopSearchCategory < ApplicationRecord
+  belongs_to :coffee_shop
+  belongs_to :search_category
 end

--- a/app/models/coffee_shop_search_category.rb
+++ b/app/models/coffee_shop_search_category.rb
@@ -1,0 +1,2 @@
+class CoffeeShopSearchCategory < ApplicationRecord
+end

--- a/app/models/search_category.rb
+++ b/app/models/search_category.rb
@@ -1,0 +1,2 @@
+class SearchCategory < ApplicationRecord
+end

--- a/app/models/search_category.rb
+++ b/app/models/search_category.rb
@@ -1,4 +1,13 @@
 class SearchCategory < ApplicationRecord
   has_many :coffee_shop_search_categories, dependent: :destroy
   has_many :coffee_shops, :through => :coffee_shop_search_categories
+  
+  #空白禁止
+  validates :name, presence: true
+  
+  # 重複禁止
+	validates :name, uniqueness: true
+	
+	# 文字数
+	validates :name, length: { maximum: 15}
 end

--- a/app/models/search_category.rb
+++ b/app/models/search_category.rb
@@ -1,2 +1,4 @@
 class SearchCategory < ApplicationRecord
+  has_many :coffee_shop_search_categories, dependent: :destroy
+  has_many :coffee_shops, :through => :coffee_shop_search_categories
 end

--- a/app/views/dashboard/coffee_shops/edit.html.erb
+++ b/app/views/dashboard/coffee_shops/edit.html.erb
@@ -29,6 +29,12 @@
   <br>
   画像３<%= f.text_field :third_image_url %>
   <br>
+  <div class="check_box">
+    <%= f.collection_check_boxes(:search_category_ids, SearchCategory.all, :id, :name) do |b| %>
+      <%= b.label { b.check_box + b.text } %>
+    <% end %>
+  </div>
+  
   <%= f.submit "更新" %>
 <% end %>
 

--- a/app/views/dashboard/coffee_shops/new.html.erb
+++ b/app/views/dashboard/coffee_shops/new.html.erb
@@ -29,6 +29,12 @@
   <br>
   画像３<%= f.text_field :third_image_url %>
   <br>
+  <div class="check_box">
+    <%= f.collection_check_boxes(:search_category_ids, SearchCategory.all, :id, :name) do |b| %>
+      <%= b.label { b.check_box + b.text } %>
+    <% end %>
+  </div>
+  
   <%= f.submit "追加" %>
 <% end %>
 

--- a/app/views/dashboard/search_categories/edit.html.erb
+++ b/app/views/dashboard/search_categories/edit.html.erb
@@ -1,0 +1,9 @@
+<h1>カテゴリ編集</h1>
+
+<%= form_with model: @search_category, url: dashboard_search_category_path(@search_category), local: true do |f| %>
+  <%= f.label :name, "カテゴリ名" %>
+  <%= f.text_field :name %>
+  
+  <%= f.submit "更新" %>
+<% end %>
+<%= link_to "カテゴリ一覧に戻る", dashboard_search_categories_path %>

--- a/app/views/dashboard/search_categories/index.html.erb
+++ b/app/views/dashboard/search_categories/index.html.erb
@@ -1,0 +1,34 @@
+<h1>カテゴリ一覧</h1>
+
+<%= form_with(model: @search_category, url: dashboard_search_categories_path, local: true) do |f| %>
+  <%= f.label :name, "カテゴリ名" %>
+  <%= f.text_field :name %>
+  
+  <%= f.submit "新規作成" %>
+<% end %>
+
+<table border="1">
+  <thead>
+    <tr>
+      <th>ID</th>
+      <th>カテゴリ</th>
+      <th></th>
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @search_categories.each do |search_category| %>
+    <tr>
+      <td><%= search_category.id %></td>
+      <td><%= search_category.name %></td>
+      <td>
+        <%= link_to "編集", edit_dashboard_search_category_path(search_category) %>
+        
+      </td>
+      <td>
+        <%= link_to "削除", dashboard_search_category_path(search_category), method: :delete, data: { confirm: 'Are you sure?' } %>
+      </td>
+    </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/layouts/dashboard/_sidebar.html.erb
+++ b/app/views/layouts/dashboard/_sidebar.html.erb
@@ -9,5 +9,5 @@
   <br>
   <b>検索条件管理</b>
   <br>
-    カテゴリ一覧
+    <%= link_to "カテゴリ一覧",dashboard_search_categories_path %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   
   namespace :dashboard do
     resources :coffee_shops, except: [:show]
+    resources :search_categories, except: [:new]
   end
   
   devise_for :users, :controllers => {

--- a/db/migrate/20211014111024_create_search_categories.rb
+++ b/db/migrate/20211014111024_create_search_categories.rb
@@ -1,7 +1,8 @@
 class CreateSearchCategories < ActiveRecord::Migration[5.2]
   def change
     create_table :search_categories do |t|
-
+      t.string :name 
+      
       t.timestamps
     end
   end

--- a/db/migrate/20211014111024_create_search_categories.rb
+++ b/db/migrate/20211014111024_create_search_categories.rb
@@ -1,0 +1,8 @@
+class CreateSearchCategories < ActiveRecord::Migration[5.2]
+  def change
+    create_table :search_categories do |t|
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20211014112346_create_coffee_shop_search_categories.rb
+++ b/db/migrate/20211014112346_create_coffee_shop_search_categories.rb
@@ -1,0 +1,10 @@
+class CreateCoffeeShopSearchCategories < ActiveRecord::Migration[5.2]
+  def change
+    create_table :coffee_shop_search_categories do |t|
+      t.integer :coffee_shop_id
+      t.integer :search_category_id
+      
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_03_104233) do
+ActiveRecord::Schema.define(version: 2021_10_14_112346) do
+
+  create_table "coffee_shop_search_categories", force: :cascade do |t|
+    t.integer "coffee_shop_id"
+    t.integer "search_category_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "coffee_shops", force: :cascade do |t|
     t.string "name"
@@ -27,6 +34,12 @@ ActiveRecord::Schema.define(version: 2021_10_03_104233) do
     t.string "first_image_url"
     t.string "second_image_url"
     t.string "third_image_url"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "search_categories", force: :cascade do |t|
+    t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/test/controllers/dashboard/search_categories_controller_test.rb
+++ b/test/controllers/dashboard/search_categories_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class Dashboard::SearchCategoriesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/coffee_shop_search_categories.yml
+++ b/test/fixtures/coffee_shop_search_categories.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/search_categories.yml
+++ b/test/fixtures/search_categories.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/coffee_shop_search_category_test.rb
+++ b/test/models/coffee_shop_search_category_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class CoffeeShopSearchCategoryTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/search_category_test.rb
+++ b/test/models/search_category_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class SearchCategoryTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# 背景
- この機能が必要な理由
検索用のカテゴリを設けることで、店舗をイメージで検索できるようにするため

- どういう機能なのか
店舗の特徴にあったカテゴリを設けて、そのカテゴリをもとに検索を行う

- なぜこのPR単位なのか
カテゴリの登録、編集、削除、店舗のカテゴリを登録できるようにする
他にも同様の方法で検索条件を随時追加予定
検索機能についてはエリアを絞ってから検索を行いたいので、
エリア検索機能が完成してから作成する

# やったこと
## コードベース
- 設計方針
  - 一つの店舗に対してカテゴリは複数可能にするため、店舗とカテゴリは多対多の関係
中間テーブルを用いて、機能を追加する
[参考にしたWEBページ](https://qiita.com/1stMinos/items/0487105994d9281221d4) 
  - カテゴリは今後も追加や編集が行えること

- model
  - 店舗`Coffrrshop`は複数の検索カテゴリ`search_category`を中間テーブル`coffee_shop_search_categries`を通してもつ
  - 検索カテゴリ`search_category`は複数の店舗`Coffrrshop`を中間テーブル`coffee_shop_search_categries`を通してもつ
  - 中間テーブル`coffee_shop_search_categries`は店舗`Coffrrshop`と検索カテゴリ`search_category`を一つ持つ
  - 検索カテゴリのバリデーション
空白禁止`presence`
重複禁止`uniqueness`
文字数`length` 最大15文字

- view
  - 検索カテゴリを一覧表示と新規追加するための画面を作成
  - 検索カテゴリの編集画面を作成
  - 店舗の登録と編集画面に検索カテゴリを表示

# 画面レイアウト
※デザインは後日調整
- カテゴリ一覧画面
![image](https://user-images.githubusercontent.com/87374457/137574968-e5c866d5-a087-4c4d-9239-52242fd03521.png)

- カテゴリ編集画面
できるなら一覧画面で編集もしたい
![image](https://user-images.githubusercontent.com/87374457/137574985-e2036dce-3622-4e2e-a4f2-9fcc992214a3.png)

- 店舗追加画面
![image](https://user-images.githubusercontent.com/87374457/137574999-424ee9b9-f4bb-4179-80e5-84061e64edc8.png)

- 店舗編集画面
![image](https://user-images.githubusercontent.com/87374457/137575015-2ca6acad-fbc4-4010-8a79-d48cb55ae2d9.png)

# 検証内容
- [x] カテゴリ一覧画面が表示できるか
- [x] カテゴリが追加できるか
- [x] カテゴリが編集できるか
- [x] カテゴリが削除できるか
- [x] カテゴリのバリデーションが正しく判定されているか

| 入力値 | 結果 |
| --- | --- |
| 空白 | 登録されない |
| コーヒーがおいしい(重複) | 登録されない |
| カテゴリ名称16文字以上！！！！ | 登録されない |

- [x] カテゴリを削除時に表示される確認メッセージをキャンセルすると削除がキャンセルされるか
- [x] カテゴリを削除した際に、中間テーブルも削除されているか
- [x] 店舗登録画面から店舗にカテゴリを登録できるか
- [x] 店舗編集画面で登録されているカテゴリがチェックがついた状態で表示されるか
- [x] 店舗に登録されているカテゴリの編集ができるか