### PR TITLE
ユーザー情報の編集機能の追加

### DIFF
--- a/app/assets/javascripts/users.coffee
+++ b/app/assets/javascripts/users.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the users controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/dashboard/search_categories_controller.rb
+++ b/app/controllers/dashboard/search_categories_controller.rb
@@ -12,17 +12,24 @@ class Dashboard::SearchCategoriesController < ApplicationController
   
   def create
     @search_category = SearchCategory.new(search_category_params)
-    @search_category.save
-    redirect_to dashboard_search_categories_path
+    if @search_category.save
+      redirect_to dashboard_search_categories_path, notice: '登録完了'
+    else
+      flash[:alert] = @search_category.errors.full_messages
+      redirect_back(fallback_location: dashboard_search_categories_path)
+    end
   end
   
   def edit
   end
   
   def update
-    @search_category.update(search_category_params)
-    @search_category.save
-    redirect_to dashboard_search_categories_path
+    if @search_category.update(search_category_params)
+      redirect_to dashboard_search_categories_path, notice: '変更完了'
+    else
+      flash[:alert] = @search_category.errors.full_messages
+      redirect_back(fallback_location: dashboard_search_categories_path)
+    end
   end
   
   def destroy

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -12,7 +12,18 @@ class UsersController < ApplicationController
   def mypage
   end
   
+  def update_password
+    if password_set? && @user.update_password(user_params)
+      flash[:notice] = "パスワードは正しく更新されました"
+      redirect_to root_path
+    else
+      @user.errors.add(:password, "パスワードに不備があります")
+      render "edit_password"
+    end
+  end
   
+  def edit_password
+  end
   
   private
   def set_user
@@ -21,5 +32,10 @@ class UsersController < ApplicationController
   
   def user_params
     params.permit(:name, :email, :password, :password_confirmation, :age, :gender, :self_introduction, :image, :instagram_url)
+  end
+  
+  def password_set?
+    user_params[:password].present? && user_params[:password_confirmation].present? ?
+    true : false
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -18,6 +18,6 @@ class UsersController < ApplicationController
   end
   
   def user_params
-    params.permit(:name, :email, :password, :password_confirmation)
+    params.permit(:name, :email, :password, :password_confirmation, :age, :gender, :self_introduction, :image)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,8 +5,12 @@ class UsersController < ApplicationController
   end
 
   def update
-    @user.update_without_password(user_params)
-    redirect_to root_path 
+    if @user.update_without_password(user_params)
+      redirect_to root_path
+    else
+      flash[:alert] = @user.errors.full_messages
+      redirect_back(fallback_location: mypage_edit_users_path)
+    end
   end
 
   def mypage

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,23 @@
+class UsersController < ApplicationController
+  before_action :set_user
+  
+  def edit
+  end
+
+  def update
+    @user.update_without_password(user_params)
+    redirect_to root_path 
+  end
+
+  def mypage
+  end
+  
+  private
+  def set_user
+    @user = current_user
+  end
+  
+  def user_params
+    params.permit(:name, :email, :password, :password_confirmation)
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -12,12 +12,14 @@ class UsersController < ApplicationController
   def mypage
   end
   
+  
+  
   private
   def set_user
     @user = current_user
   end
   
   def user_params
-    params.permit(:name, :email, :password, :password_confirmation, :age, :gender, :self_introduction, :image)
+    params.permit(:name, :email, :password, :password_confirmation, :age, :gender, :self_introduction, :image, :instagram_url)
   end
 end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,0 +1,2 @@
+module UsersHelper
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,15 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable, :confirmable
+         
+  def update_password(params, *options)
+    if params[:password].blank?
+      params.delete(:password)
+      params.delete(:password_confirmation) if params[:password_confirmation].blank?
+    end
+    
+    result = update(params, *options)
+    clean_up_passwords
+    result
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,22 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable, :confirmable
          
+  # バリデーション
+  #文字数
+  validates :name, length: { maximum: 15}
+  validates :email, length: { maximum: 256}
+  validates :age, length: { maximum: 10}
+  validates :gender, length: { maximum: 10}
+  validates :self_introduction, length: { maximum: 100}
+  validates :instagram_url, length: { maximum: 50}
+  
+  # 空白禁止
+  validates :name, presence: true
+  
+  # 重複禁止
+	validates :name, uniqueness: true
+	validates :email, uniqueness: true
+         
   def update_password(params, *options)
     if params[:password].blank?
       params.delete(:password)

--- a/app/views/dashboard/coffee_shops/index.html.erb
+++ b/app/views/dashboard/coffee_shops/index.html.erb
@@ -1,7 +1,7 @@
 <h1>店舗一覧</h1>
 <%= form_with url: dashboard_coffee_shops_path, method: :get, local: true do |f|%>
   店舗名・電話番号
-  <%= f.text_area :keyword %>
+  <%= f.text_field :keyword %>
   <%= f.submit "検索" %>
 <% end %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -32,6 +32,7 @@
 
                   <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
                     <%= link_to "プロフィール変更", mypage_edit_users_path, class: "dropdown-item" %>
+                    <%= link_to "パスワード変更", mypage_edit_password_users_path, class: "dropdown-item" %>
                     <%= link_to "sign out", logout_path, method: :delete, class: "dropdown-item" %>
                     <%= link_to "管理画面", dashboard_path, class: "dropdown-item" %>
                     

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,8 +31,10 @@
                   <% end %>
 
                   <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
+                    <%= link_to "プロフィール変更", mypage_edit_users_path, class: "dropdown-item" %>
                     <%= link_to "sign out", logout_path, method: :delete, class: "dropdown-item" %>
                     <%= link_to "管理画面", dashboard_path, class: "dropdown-item" %>
+                    
                   </div>
                 </li>
               <% else %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -12,13 +12,27 @@
   <hr>
   
   <%= f.label :age, "年齢" %>
-  <%= f.text_field :age, value: @user.age, placeholder: @user.age %>
+  <% choices = [['10代', 10],['20代', 20],['30代',30],['40代',40],['50代',50],['60代',60],['シニア','シニア']] %>
+  <%= f.select :age, choices, selected: @user.age %>
+  
   
   <hr>
   
-  <%= f.label :gender, "性別" %>
-  <%= f.text_field :gender, value: @user.gender, placeholder: @user.gender %>
+  <% if @user.gender == "male" %>
+    <%= f.radio_button :gender, :male, {:checked => true } %>
+    <%= f.label :gender, "男性", {value: :male, stylr: "display: inline-block;"} %>
+  <% else %>
+    <%= f.radio_button :gender, :male %>
+    <%= f.label :gender, "男性", {value: :male, stylr: "display: inline-block;"} %>
+  <% end %>
   
+  <% if @user.gender == "female" %>
+    <%= f.radio_button :gender, :female, {:checked => true } %>
+    <%= f.label :gender, "女性", {value: :female, style: "display: inline-block;"} %>
+  <% else %>
+    <%= f.radio_button :gender, :female %>
+    <%= f.label :gender, "女性", {value: :female, style: "display: inline-block;"} %>
+  <% end %>
   <hr>
   
   <%= f.label :self_introduction, "自己紹介"%>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -2,12 +2,12 @@
 <hr>
 <%= form_with url: mypage_users_path, local: true, method: :put do |f| %>
   <%= f.label :name, "氏名" %>
-  <%= f.text_field :name, value: @user.name, placeholder: @user.name %>
+  <%= f.text_field :name, value: @user.name %>
   
   <hr>
   
   <%= f.label :email, "E-mail" %>
-  <%= f.email_field :email, value: @user.email, placeholder: @user.email %>
+  <%= f.email_field :email, value: @user.email %>
   
   <hr>
   
@@ -36,7 +36,7 @@
   <hr>
   
   <%= f.label :self_introduction, "自己紹介"%>
-  <%= f.text_area :self_introduction, value: @user.self_introduction, placeholder: @user.self_introduction %>
+  <%= f.text_area :self_introduction, value: @user.self_introduction %>
   
   <hr>
   
@@ -45,7 +45,7 @@
   <hr>
   
   <%= f.label :instagram_url, "インスタグラムのアカウント" %>
-  <%= f.text_field :instagram_url, value: @user.instagram_url, placeholder: @user.instagram_url %>
+  <%= f.text_field :instagram_url, value: @user.instagram_url %>
   
   <hr>
   

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -6,8 +6,27 @@
   
   <hr>
   
-  <%= f.label :email, "氏名" %>
+  <%= f.label :email, "E-mail" %>
   <%= f.email_field :email, value: @user.email, placeholder: @user.email %>
+  
+  <hr>
+  
+  <%= f.label :age, "年齢" %>
+  <%= f.text_field :age, value: @user.age, placeholder: @user.age %>
+  
+  <hr>
+  
+  <%= f.label :gender, "性別" %>
+  <%= f.text_field :gender, value: @user.gender, placeholder: @user.gender %>
+  
+  <hr>
+  
+  <%= f.label :self_introduction, "自己紹介"%>
+  <%= f.text_area :self_introduction, value: @user.self_introduction, placeholder: @user.self_introduction %>
+  
+  <hr>
+  
+  画像(未実装)
   
   <hr>
   

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -44,5 +44,10 @@
   
   <hr>
   
+  <%= f.label :instagram_url, "インスタグラムのアカウント" %>
+  <%= f.text_field :instagram_url, value: @user.instagram_url, placeholder: @user.instagram_url %>
+  
+  <hr>
+  
   <%= f.submit "保存" %>
 <% end %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,0 +1,15 @@
+<h1>ユーザー情報編集</h1>
+<hr>
+<%= form_with url: mypage_users_path, local: true, method: :put do |f| %>
+  <%= f.label :name, "氏名" %>
+  <%= f.text_field :name, value: @user.name, placeholder: @user.name %>
+  
+  <hr>
+  
+  <%= f.label :email, "氏名" %>
+  <%= f.email_field :email, value: @user.email, placeholder: @user.email %>
+  
+  <hr>
+  
+  <%= f.submit "保存" %>
+<% end %>

--- a/app/views/users/edit_password.html.erb
+++ b/app/views/users/edit_password.html.erb
@@ -1,0 +1,39 @@
+<div class="container">
+  <%= form_with url: mypage_password_users_path, local: true, method: :put do |f| %>
+    <div class="form-group row">
+      <%= f.label :password, "新しいパスワード", class: "col-md-3 col-form-label text-md-right" %>
+
+      <div class="col-md-7">
+        <%=
+          f.password_field :password,
+          class: "form-control #{"is-invalid" if @user.errors.messages[:password].present? }",
+          autocomplete: "new-password"
+        %>
+
+        <% if @user.errors.messages[:password].present? %>
+          <span class="invalid-feedback" role="alert">
+            <strong><%= @user.errors.messages[:password].first %></strong>
+          </span>
+        <% end %>
+      </div>
+    </div>
+
+    <div class="form-group row">
+      <%= f.label :password_confirmation, "確認用", class: "col-md-3 col-form-label text-md-right" %>
+
+      <div class="col-md-7">
+        <%=
+          f.password_field :password_confirmation,
+          class: "form-control #{"is-invalid" if @user.errors.messages[:password_confirmation].present? }",
+          autocomplete: "new-password"
+        %>
+      </div>
+    </div>
+
+    <div class="form-group d-flex justify-content-center">
+      <button type="submit" class="btn btn-danger w-25">
+        パスワード更新
+      </button>
+    </div>
+  <% end %>
+</div>

--- a/app/views/users/mypage.html.erb
+++ b/app/views/users/mypage.html.erb
@@ -1,0 +1,2 @@
+<h1>Users#mypage</h1>
+<p>Find me in app/views/users/mypage.html.erb</p>

--- a/app/views/users/update.html.erb
+++ b/app/views/users/update.html.erb
@@ -1,0 +1,2 @@
+<h1>Users#update</h1>
+<p>Find me in app/views/users/update.html.erb</p>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -157,7 +157,7 @@ Devise.setup do |config|
   # initial account confirmation) to be applied. Requires additional unconfirmed_email
   # db field (see migrations). Until confirmed, new email is stored in
   # unconfirmed_email column, and copied to email column on successful confirmation.
-  config.reconfirmable = true
+  config.reconfirmable = false
 
   # Defines which key will be used when confirming an account
   # config.confirmation_keys = [:email]

--- a/config/locales/models/ja.yml
+++ b/config/locales/models/ja.yml
@@ -2,6 +2,8 @@ ja:
   activerecord:
     models:
       coffee_shop: 店舗
+      user: ユーザー
+      search_category: 検索カテゴリ
     attributes:
       coffee_shop:
         name: 店舗名
@@ -18,3 +20,15 @@ ja:
         first_image_url: 画像１
         second_image_url: 画像２
         third_image_url: 画像３
+        
+      user:
+        name: ユーザー名
+        email: メールアドレス
+        age: 年齢
+        gender: 性別
+        self_introduction: 自己紹介
+        instagram_url: インスタグラムのアカウント
+        
+      search_category:
+        name: カテゴリ名
+        

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,8 @@ Rails.application.routes.draw do
       get "mypage", :to => "users#mypage"
       get "mypage/edit", :to => "users#edit"
       put "mypage", :to => "users#update"
+      get "mypage/edit_password", :to => "users#edit_password"
+      put "mypage/password", :to => "users#update_password"
     end
   end
   

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
+  get 'users/edit'
+  get 'users/update'
+  get 'users/mypage'
   get "dashboard", :to => "dashboard#index"
   
   resources :coffee_shops do
@@ -24,6 +27,14 @@ Rails.application.routes.draw do
     get "verify", :to => "users/registrations#verify"
     get "login", :to => "users/sessions#new"
     delete "logout", :to => "users/sessions#destroy"
+  end
+  
+  resources :users, only: [:edit, :update] do
+    collection do
+      get "mypage", :to => "users#mypage"
+      get "mypage/edit", :to => "users#edit"
+      put "mypage", :to => "users#update"
+    end
   end
   
 end

--- a/db/migrate/20211016071835_add_users.rb
+++ b/db/migrate/20211016071835_add_users.rb
@@ -4,5 +4,6 @@ class AddUsers < ActiveRecord::Migration[5.2]
     add_column :users, :gender, :string
     add_column :users, :self_introduction, :string
     add_column :users, :image, :string
+    add_column :users, :instagram_url, :string
   end
 end

--- a/db/migrate/20211016071835_add_users.rb
+++ b/db/migrate/20211016071835_add_users.rb
@@ -1,0 +1,8 @@
+class AddUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :age, :string
+    add_column :users, :gender, :string
+    add_column :users, :self_introduction, :string
+    add_column :users, :image, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -61,6 +61,7 @@ ActiveRecord::Schema.define(version: 2021_10_16_071835) do
     t.string "gender"
     t.string "self_introduction"
     t.string "image"
+    t.string "instagram_url"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_14_112346) do
+ActiveRecord::Schema.define(version: 2021_10_16_071835) do
 
   create_table "coffee_shop_search_categories", force: :cascade do |t|
     t.integer "coffee_shop_id"
@@ -57,6 +57,10 @@ ActiveRecord::Schema.define(version: 2021_10_14_112346) do
     t.string "unconfirmed_email"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "age"
+    t.string "gender"
+    t.string "self_introduction"
+    t.string "image"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+class UsersControllerTest < ActionDispatch::IntegrationTest
+  test "should get edit" do
+    get users_edit_url
+    assert_response :success
+  end
+
+  test "should get update" do
+    get users_update_url
+    assert_response :success
+  end
+
+  test "should get mypage" do
+    get users_mypage_url
+    assert_response :success
+  end
+
+end


### PR DESCRIPTION
# 背景
- この機能が必要な理由
ユーザーの登録時にはユーザーネームとメールアドレス、パスワードのみしか登録しないが、
他の人が自分のプロフィールを見れる機能を実装予定でその際にはほかの情報も表示できるようにするため
また、ユーザー名、メールアドレス、パスワードの変更が行えるようにするため

- どういう機能なのか
自分のプロフィール情報を変更する
<プロフィール情報> 
ユーザーネーム、メールアドレス、パスワード、性別、年齢、自己紹介、アイコンの画像、インスタのアカウント

- なぜこのＰR単位なのか
自分で編集できる範囲の機能のため
ユーザー一覧も作成するが管理者画面の機能なので違うPRで行う
退会機能についてもユーザー一覧機能作成時に合わせて実装する

# やったこと
## コードベース
- 設計方針
  - ユーザー情報は一覧画面で表示でき一括で変更できる
  - パスワードは別画面で変更をする
  - それぞれの画面へは右上のメニューから
  - userのカラムに不足分を追加する(年齢、性別、自己紹介、アイコンの画像、Instagramのアカウント名)

- model
  - パスワードの間違いがないか確認する機能を追加
  - バリデーション
    - 文字数
名前：15文字
メールアドレス：256文字
自己紹介：100文字
    - 空白禁止
名前、メールアドレス
    - 重複禁止
名前、メールアドレス

- controller
  - バリデーションエラーの内容を表示する 
  - パスワード変更時に正しく更新できたか分かるようにメッセージを表示させる
    - 確認事項は値は空白でないか、確認用のパスワードと同じ値になっているか

- view
  - トップページの右上のメニューにプロフェール変更とパスワード変更を追加
  - ユーザー情報編集画面
    - 年齢はセレクトボックス
    - 性別はラジオボタン
好きに入力できるのも面白そうだったが、後々データとして使うときのために入力値は指定

# 画面レイアウト
※デザインは後日調整
- ユーザー情報変更画面
![image](https://user-images.githubusercontent.com/87374457/137614183-d2a73dfc-abbc-4c76-9d81-5e7243f64cc6.png)

- パスワード変更画面
![image](https://user-images.githubusercontent.com/87374457/137614190-6196d8db-c402-44fc-aa8b-a6641c7318b7.png)

# 検証内容
- [x] ユーザー情報編集画面が表示できるか
- [x] ユーザー情報の更新ができるか
- [x] バリデーションエラーの際に、エラーメッセージが表示されるか

| 項目 | 入力値 | 結果 |
| --- | --- | ---- |
|氏名 | ユーザー名16文字！！！！！！！ | 〇|
|氏名| 空白|〇|
|メースアドレス|空白| 〇|

- [x] パスワード変更画面が表示されるか
- [x] パスワードの変更ができるか
- [x] パスワードが空白の時にエラーメッセージが表示されるか
- [x] パスワードが確認用と異なる場合にエラーメッセージが表示されるか