### PR TITLE
お気に入り機能の追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,9 @@ gem 'pry-rails'
 # エラーメッセージを日本語化できる
 gem 'rails-i18n'
 
+ # socialiizatioinを使用できる
+ gem 'socialization'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -198,6 +198,8 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
+    socialization (1.2.3)
+      activerecord
     spring (2.1.1)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
@@ -254,6 +256,7 @@ DEPENDENCIES
   rails-i18n
   sass-rails (~> 5.0)
   selenium-webdriver
+  socialization
   spring
   spring-watcher-listen (~> 2.0.0)
   sqlite3

--- a/app/assets/stylesheets/cafe_de_niche.scss
+++ b/app/assets/stylesheets/cafe_de_niche.scss
@@ -61,3 +61,13 @@
   font-size: 80%;
   color: #e3342f
 }
+
+.favorite-button {
+  border-radius: 2px;
+  border: solid 1px #0fbe9f;
+  background-color: #ffffff;
+}
+
+.text-favorite {
+  color: #0fbe9f;
+}

--- a/app/controllers/coffee_shops_controller.rb
+++ b/app/controllers/coffee_shops_controller.rb
@@ -46,6 +46,12 @@ class CoffeeShopsController < ApplicationController
     @coffee_shops = @coffee_shop_search_service.search
   end
   
+  def favorite
+    @coffee_shop = CoffeeShop.find(params[:id])
+    current_user.toggle_like!(@coffee_shop)
+    redirect_to coffee_shop_url @coffee_shop
+  end
+  
   private
     def coffee_shop_params
       params.require(:coffee_shop).permit(:name, :shop_url, :address, :tell, :access, :business_start_hour, :business_end_hour, :regular_holiday, :instagram_url, :instagram_spot_url, :municipalitie_id, :first_image_url, :second_image_url, :third_image_url)

--- a/app/controllers/coffee_shops_controller.rb
+++ b/app/controllers/coffee_shops_controller.rb
@@ -7,6 +7,7 @@ class CoffeeShopsController < ApplicationController
     @coffee_shop = CoffeeShop.find(params[:id])
     @reviews = @coffee_shop.reviews
     @review = Review.new
+    @likers = @coffee_shop.likers(User)
     # 店舗のレビューの平均点を計算
     @review_average_score = ReviewAverageScoreService.new(@reviews).calculation
   end
@@ -67,6 +68,8 @@ class CoffeeShopsController < ApplicationController
       hash[:review_score_search_type] = params[:review_score_search_type]
       hash[:review_count] = params[:review_count]
       hash[:review_count_search_type] = params[:review_count_search_type]
+      hash[:favorite_count] = params[:favorite_count]
+      hash[:favorite_count_search_type] = params[:favorite_count_search_type]
       hash
     end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -38,10 +38,26 @@ class UsersController < ApplicationController
   
   def show
     @show_user = User.find_by(id: params[:id])
+    @followers = @show_user.followers(User)
+    @reviews = Review.where(user_id: params[:id])
   end
   
   def favorite
     @favorites = @user.likees(CoffeeShop)
+  end
+
+  def follow
+    @follow_user = User.find_by(id: params[:id])
+    current_user.toggle_follow!(@follow_user)
+    redirect_to user_path(@follow_user.id)
+  end
+  
+  def following
+    @follow_users = @user.followees(User)
+  end
+  
+  def follower 
+    @follower = @user.followers(User)
   end
   
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -40,6 +40,10 @@ class UsersController < ApplicationController
     @show_user = User.find_by(id: params[:id])
   end
   
+  def favorite
+    @favorites = @user.likees(CoffeeShop)
+  end
+  
   private
   def set_user
     @user = current_user

--- a/app/models/coffee_shop.rb
+++ b/app/models/coffee_shop.rb
@@ -3,6 +3,7 @@ class CoffeeShop < ApplicationRecord
 	has_many :search_categories, :through => :coffee_shop_search_categories
 	has_many :reviews
 	accepts_nested_attributes_for :coffee_shop_search_categories, allow_destroy: true
+	acts_as_likeable
 	
 	# バリデーション
 	# 必ず登録してほしい項目

--- a/app/models/follow.rb
+++ b/app/models/follow.rb
@@ -1,0 +1,2 @@
+class Follow < Socialization::ActiveRecordStores::Follow
+end

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -1,0 +1,2 @@
+class Like < Socialization::ActiveRecordStores::Like
+end

--- a/app/models/mention.rb
+++ b/app/models/mention.rb
@@ -1,0 +1,2 @@
+class Mention < Socialization::ActiveRecordStores::Mention
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,9 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable, :confirmable
+  acts_as_liker
+  acts_as_followable
+  acts_as_follower
          
   # バリデーション
   #文字数

--- a/app/service/coffee_shop_search_service.rb
+++ b/app/service/coffee_shop_search_service.rb
@@ -7,6 +7,8 @@ class CoffeeShopSearchService
     @review_score_search_type = hash[:review_score_search_type]
     @review_count = hash[:review_count]
     @review_count_search_type = hash[:review_count_search_type]
+    @favorite_count = hash[:favorite_count]
+    @favorite_count_search_type = hash[:favorite_count_search_type]
   end
   
   def search
@@ -26,6 +28,9 @@ class CoffeeShopSearchService
     
     # レビュー数検索
     search_by_review_count if @review_count.present?
+    
+    # お気に入り数検索
+    search_by_favorite_count if @favorite_count.present?
     
     @coffee_shops
   end
@@ -84,6 +89,29 @@ class CoffeeShopSearchService
         coffee_shop_ids << coffee_shop.id
       # 以下
       elsif @review_count_search_type.eql?("less_than") && @review_count.to_i >= coffee_shop.reviews.count
+        coffee_shop_ids << coffee_shop.id
+      end
+    end
+    # 条件にあう店舗を取得
+    @coffee_shops = @coffee_shops.where(id: coffee_shop_ids)
+  end
+  
+  # お気に入り数検索
+  def search_by_favorite_count
+    coffee_shop_ids = []
+    @coffee_shops.each do |coffee_shop|
+      # 0が検索条件にあれば0件の店舗のみ表示
+      if @favorite_count.eql?("0")
+        coffee_shop_ids << coffee_shop.id if coffee_shop.likers(User).count.zero?
+        next
+      end
+      
+      next if coffee_shop.likers(User).count.zero?
+      # 以上
+      if @favorite_count_search_type.eql?("more_than") && @favorite_count.to_i <= coffee_shop.likers(User).count
+        coffee_shop_ids << coffee_shop.id
+      # 以下
+      elsif @favorite_count_search_type.eql?("less_than") && @favorite_count.to_i >= coffee_shop.likers(User).count
         coffee_shop_ids << coffee_shop.id
       end
     end

--- a/app/views/coffee_shops/show.html.erb
+++ b/app/views/coffee_shops/show.html.erb
@@ -1,4 +1,8 @@
 <h1>CoffeeShops#show</h1>
+	<%= link_to favorite_coffee_shop_path, class: "btn favorite-button text-favorite" do %>
+		<i class="fa fa-heart"></i><%= current_user.likes?(@coffee_shop) ? "お気に入り解除" : "お気に入り" %>
+	<% end %>
+	<br>
   店舗名<%= @coffee_shop.name %>
   <br>
   店舗HP<%= @coffee_shop.shop_url %>

--- a/app/views/coffee_shops/show.html.erb
+++ b/app/views/coffee_shops/show.html.erb
@@ -3,35 +3,39 @@
 		<i class="fa fa-heart"></i><%= current_user.likes?(@coffee_shop) ? "お気に入り解除" : "お気に入り" %>
 	<% end %>
 	<br>
-  店舗名<%= @coffee_shop.name %>
+	お気に入り数：<%= @likers.count %>
+	<br>
+  店舗名：<%= @coffee_shop.name %>
   <br>
-  店舗HP<%= @coffee_shop.shop_url %>
+  店舗HP：<%= @coffee_shop.shop_url %>
   <br>
-  住所<%= @coffee_shop.address %>
+  住所：<%= @coffee_shop.address %>
   <br>
-  電話番号<%= @coffee_shop.tell %>
+  電話番号：<%= @coffee_shop.tell %>
   <br>
-  アクセス<%= @coffee_shop.access %>
+  アクセス：<%= @coffee_shop.access %>
   <br>
-  営業開始時間<%= @coffee_shop.business_start_hour %>
+  営業開始時間：<%= @coffee_shop.business_start_hour %>
   <br>
-  営業終了時間<%= @coffee_shop.business_end_hour %>
+  営業終了時間：<%= @coffee_shop.business_end_hour %>
   <br>
-  定休日<%= @coffee_shop.regular_holiday %>
+  定休日：<%= @coffee_shop.regular_holiday %>
   <br>
-  Instagram公式URL<%= @coffee_shop.instagram_url %>
+  Instagram公式URL：<%= @coffee_shop.instagram_url %>
   <br>
-  InstagramスポットURL<%= @coffee_shop.instagram_spot_url %>
+  InstagramスポットURL：<%= @coffee_shop.instagram_spot_url %>
   <br>
-  エリアid<%= @coffee_shop.municipalitie_id %>
+  エリアid：<%= @coffee_shop.municipalitie_id %>
   <br>
-  画像１<%= @coffee_shop.first_image_url %>
+  画像１：<%= @coffee_shop.first_image_url %>
   <br>
-  画像２<%= @coffee_shop.second_image_url %>
+  画像２：<%= @coffee_shop.second_image_url %>
   <br>
-  画像３<%= @coffee_shop.third_image_url %>
+  画像３：<%= @coffee_shop.third_image_url %>
 	<hr>
-	レビュー点数<%= @review_average_score %>
+	レビュー数：<%= @reviews.count %>
+	<hr>
+	レビュー点数：<%= @review_average_score %>
 	<hr>
 	
 	<% @reviews.each do |review| %>

--- a/app/views/coffee_shops/show.html.erb
+++ b/app/views/coffee_shops/show.html.erb
@@ -5,6 +5,11 @@
 	<br>
 	お気に入り数：<%= @likers.count %>
 	<br>
+	お気に入りユーザー：
+	<% @likers.last(5).each do |liker| %>
+		<%= link_to liker.name, user_path(liker.id) %>,
+	<% end %>
+	<br>
   店舗名：<%= @coffee_shop.name %>
   <br>
   店舗HP：<%= @coffee_shop.shop_url %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -33,6 +33,7 @@
                   <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
                     <%= link_to "プロフィール変更", mypage_edit_users_path, class: "dropdown-item" %>
                     <%= link_to "パスワード変更", mypage_edit_password_users_path, class: "dropdown-item" %>
+                    <%= link_to "フォロワー", follower_users_path, class: "dropdown-item" %>
                     <%= link_to "sign out", logout_path, method: :delete, class: "dropdown-item" %>
                     <%= link_to "管理画面", dashboard_path, class: "dropdown-item" %>
                     

--- a/app/views/users/favorite.html.erb
+++ b/app/views/users/favorite.html.erb
@@ -1,0 +1,11 @@
+<h1>お気に入り</h1>
+
+<hr>
+
+<% @favorites.each do |favorite| %>
+  <%= favorite.name %>
+  <%= link_to favorite_coffee_shop_path(favorite) do %>
+    解除
+  <% end %>
+  <hr>
+<% end %>

--- a/app/views/users/follower.html.erb
+++ b/app/views/users/follower.html.erb
@@ -1,0 +1,8 @@
+<h1>フォロワー</h1>
+
+<hr>
+
+<% @follower.each do |follower| %>
+  <%= link_to follower.name, user_path(follower.id) %>
+  <hr>
+<% end %>

--- a/app/views/users/following.html.erb
+++ b/app/views/users/following.html.erb
@@ -1,0 +1,11 @@
+<h1>フォロー</h1>
+
+<hr>
+
+<% @follow_users.each do |follow_user| %>
+  <%= follow_user.name %>
+  <%= link_to follow_user_path(follow_user) do %>
+    解除
+  <% end %>
+  <hr>
+<% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,5 +1,13 @@
 <h1>ユーザー詳細</h1>
 
+<% unless current_user == @show_user %>
+  <%= link_to follow_user_path, class: "btn favorite-button text-favorite" do %>
+  	<i class="fa fa-heart"></i><%= current_user.follows?(@show_user) ? "フォロー解除" : "フォロー" %><br>
+  <% end %>
+<%end %>
+<br>
+フォロワー数：<%= @followers.count %>
+<br>
 名前：<%= @show_user.name %>
 <br>
 年齢：<%= @show_user.age %>
@@ -8,5 +16,19 @@
 <br>
 自己紹介：<%= @show_user.self_introduction %>
 <br>
+お気に入り店舗:<%= @show_user.likees(CoffeeShop).count %>件
+<br>
+<% @show_user.likees(CoffeeShop).each do |favorite_coffee_shop| %>
+  <%= link_to favorite_coffee_shop.name, coffee_shop_path(favorite_coffee_shop) %>|
+<%end %>
+<br>
+レビュー：<%= @reviews.count %>件
+<br>
+<% @reviews.last(10).each do |review| %>
+  店舗名<%= link_to review.coffee_shop.name, coffee_shop_path(review.coffee_shop) %><br>
+  スコア<%= review.review_score %><br>
+  <%= review.review_comment %>
+  <hr>
+<% end %>
 
 <%= link_to "戻る", :back %>

--- a/app/views/web/index.html.erb
+++ b/app/views/web/index.html.erb
@@ -61,7 +61,7 @@
       <br>
       <%= f.number_field :review_count %>
       <%= f.radio_button :review_count_search_type, :more_than, {:checked => true} %>
-      <%= f.label :review_count_search_type, "以上", {value: :more_than, stylr: "display: inline-block;"} %>
+      <%= f.label :review_count_search_type, "以上", {value: :more_than, style: "display: inline-block;"} %>
       <%= f.radio_button :review_count_search_type, :less_than %>
       <%= f.label :review_count_search_type, "以下", {value: :less_than, style: "display: inline-block;"} %>
     <hr>
@@ -69,7 +69,7 @@
       <br>
       <%= f.number_field :favorite_count %>
       <%= f.radio_button :favorite_count_search_type, :more_than, {:checked => true} %>
-      <%= f.label :favorite_count_search_type, "以上", {value: :more_than, stylr: "display: inline-block;"} %>
+      <%= f.label :favorite_count_search_type, "以上", {value: :more_than, style: "display: inline-block;"} %>
       <%= f.radio_button :favorite_count_search_type, :less_than %>
       <%= f.label :favorite_count_search_type, "以下", {value: :less_than, style: "display: inline-block;"} %>
     <hr>

--- a/app/views/web/index.html.erb
+++ b/app/views/web/index.html.erb
@@ -8,6 +8,10 @@
         <%= current_user.name %>
         さん
         </p>
+        お気に入り店舗
+        <% current_user.likees(CoffeeShop).each do |favorite_coffee_shop| %>
+          <%= link_to favorite_coffee_shop.name, coffee_shop_path(favorite_coffee_shop) %>
+        <% end %>
       <!--サインインしていない-->
       <% else %>
         <div class="cover-container-befoer-sign-in">

--- a/app/views/web/index.html.erb
+++ b/app/views/web/index.html.erb
@@ -3,14 +3,18 @@
       <!-- user_signed_in? はユーザがログインしているか調べるdeviseのHelperメソッド -->
       <!--サインインしている-->
       <% if user_signed_in? %>
-        <p>サインイン済み</p>
         <p>ようこそ
         <%= current_user.name %>
         さん
         </p>
-        お気に入り店舗
-        <% current_user.likees(CoffeeShop).each do |favorite_coffee_shop| %>
+        <%= link_to "お気に入り店舗:", favorite_users_path %>
+        <% current_user.likees(CoffeeShop).last(5).each do |favorite_coffee_shop| %>
           <%= link_to favorite_coffee_shop.name, coffee_shop_path(favorite_coffee_shop) %>
+        <% end %>
+        <br>
+        <%= link_to "フォロー:", following_users_path %>
+        <% current_user.followees(User).last(5).each do |follow_user| %>
+          <%= link_to follow_user.name, user_path(follow_user.id) %>
         <% end %>
       <!--サインインしていない-->
       <% else %>
@@ -61,9 +65,16 @@
       <%= f.radio_button :review_count_search_type, :less_than %>
       <%= f.label :review_count_search_type, "以下", {value: :less_than, style: "display: inline-block;"} %>
     <hr>
+      お気に入り数検索　※0で検索するとお気に入り数0のお店のみ表示します。
+      <br>
+      <%= f.number_field :favorite_count %>
+      <%= f.radio_button :favorite_count_search_type, :more_than, {:checked => true} %>
+      <%= f.label :favorite_count_search_type, "以上", {value: :more_than, stylr: "display: inline-block;"} %>
+      <%= f.radio_button :favorite_count_search_type, :less_than %>
+      <%= f.label :favorite_count_search_type, "以下", {value: :less_than, style: "display: inline-block;"} %>
+    <hr>
       <%= f.submit :search %>
     <% end %> 
-      
   </div>
   
   <hr>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,9 @@ Rails.application.routes.draw do
   get "dashboard", :to => "dashboard#index"
   
   resources :coffee_shops do
+    member do 
+      get :favorite
+    end
     get :search, on: :collection
     resources :reviews, only: [:create]
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,6 +41,12 @@ Rails.application.routes.draw do
       get "mypage/edit_password", :to => "users#edit_password"
       put "mypage/password", :to => "users#update_password"
       delete "mypage/delete", :to => "users#destroy"
+      get "favorite", :to => "users#favorite"
+      get "following", :to => "users#following"
+      get "follower", :to => "users#follower" 
+    end
+    member do 
+      get :follow
     end
   end
   

--- a/db/migrate/20211030100519_create_follows.rb
+++ b/db/migrate/20211030100519_create_follows.rb
@@ -1,0 +1,14 @@
+class CreateFollows < ActiveRecord::Migration[5.2]
+  def change
+    create_table :follows do |t|
+      t.string  :follower_type
+      t.integer :follower_id
+      t.string  :followable_type
+      t.integer :followable_id
+      t.datetime :created_at
+    end
+
+    add_index :follows, ["follower_id", "follower_type"],     :name => "fk_follows"
+    add_index :follows, ["followable_id", "followable_type"], :name => "fk_followables"
+  end
+end

--- a/db/migrate/20211030100520_create_likes.rb
+++ b/db/migrate/20211030100520_create_likes.rb
@@ -1,0 +1,14 @@
+class CreateLikes < ActiveRecord::Migration[5.2]
+  def change
+    create_table :likes do |t|
+      t.string  :liker_type
+      t.integer :liker_id
+      t.string  :likeable_type
+      t.integer :likeable_id
+      t.datetime :created_at
+    end
+
+    add_index :likes, ["liker_id", "liker_type"],       :name => "fk_likes"
+    add_index :likes, ["likeable_id", "likeable_type"], :name => "fk_likeables"
+  end
+end

--- a/db/migrate/20211030100521_create_mentions.rb
+++ b/db/migrate/20211030100521_create_mentions.rb
@@ -1,0 +1,14 @@
+class CreateMentions < ActiveRecord::Migration[5.2]
+  def change
+    create_table :mentions do |t|
+      t.string  :mentioner_type
+      t.integer :mentioner_id
+      t.string  :mentionable_type
+      t.integer :mentionable_id
+      t.datetime :created_at
+    end
+
+    add_index :mentions, ["mentioner_id", "mentioner_type"],   :name => "fk_mentions"
+    add_index :mentions, ["mentionable_id", "mentionable_type"], :name => "fk_mentionables"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_23_063853) do
+ActiveRecord::Schema.define(version: 2021_10_30_100521) do
 
   create_table "coffee_shop_search_categories", force: :cascade do |t|
     t.integer "coffee_shop_id"
@@ -36,6 +36,36 @@ ActiveRecord::Schema.define(version: 2021_10_23_063853) do
     t.string "third_image_url"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "follows", force: :cascade do |t|
+    t.string "follower_type"
+    t.integer "follower_id"
+    t.string "followable_type"
+    t.integer "followable_id"
+    t.datetime "created_at"
+    t.index ["followable_id", "followable_type"], name: "fk_followables"
+    t.index ["follower_id", "follower_type"], name: "fk_follows"
+  end
+
+  create_table "likes", force: :cascade do |t|
+    t.string "liker_type"
+    t.integer "liker_id"
+    t.string "likeable_type"
+    t.integer "likeable_id"
+    t.datetime "created_at"
+    t.index ["likeable_id", "likeable_type"], name: "fk_likeables"
+    t.index ["liker_id", "liker_type"], name: "fk_likes"
+  end
+
+  create_table "mentions", force: :cascade do |t|
+    t.string "mentioner_type"
+    t.integer "mentioner_id"
+    t.string "mentionable_type"
+    t.integer "mentionable_id"
+    t.datetime "created_at"
+    t.index ["mentionable_id", "mentionable_type"], name: "fk_mentionables"
+    t.index ["mentioner_id", "mentioner_type"], name: "fk_mentions"
   end
 
   create_table "reviews", force: :cascade do |t|


### PR DESCRIPTION
# 背景
- この機能が必要な理由
ユーザーが店舗、他ユーザーをお気に入りに設定できるようにするため
お気に入りの数が多い、（人気の）店舗が検索できるようにするため

- どういう機能なのか
店舗、他ユーザーをお気に入り登録できる機能
毎回検索しなくても一覧から詳細ページにいける

- なぜこのPR単位なのか
[socialization](https://github.com/cmer/socialization)というGemを使うことで、
お気に入り登録とフォローの機能が実装でいるため、
まとめた単位で作成

# やったこと
## コードベース
- 設計方針
店舗詳細ページからお気に入り登録ができ、
ユーザー詳細ページからフォローの登録/解除ができる
フォロワーの一覧は右上のタブから
トップページにお気に入り登録した店舗、フォローしたユーザーを一部(最後の5つ)表示
全て確認したい場合は一覧ページから確認する
店舗詳細ページにはお気に入り登録しているユーザー数と一部のユーザーを表示
ユーザー詳細ページにはフォロワー数とお気に入り登録している店舗を表示

- model
`coffee_shop`と`user`にGemを使うための文を追記
おそらくお気に入り登録、フォローの機能でモデル同士の関係を紐づけるための設定
お気に入り数検索追加のために検索サービスモデルに機能を追加
レビュー数検索と仕様は同じ

- controller
  - `coffee_shop`コントローラー
`show`にお気に入り登録されているユーザーを持った変数`@likers`を追加
これも用いて、お気に入り数とユーザーを表示する
お気に入り状態を切り替える`favorite`を作成
一覧から解除するときに店舗詳細にいってしまうので、
切り替えではなく登録、解除別にして作った方がよかったかもしれないが、
動作は問題ないので使いにくいなと感じたら修正する

  - `user`コントローラー
`favorite`、`follow`、`following`、`follower`の4つのアクションを作成
お気に入り機能に対しては一覧表示のための`favorite`
フォロー機能に対しては、フォロー登録解除のための`follow`
フォロー一覧表示のための`following`、フォロワー表示のための`follower`
こちらも一覧からフォロー解除するとユーザー詳細にいってしまう、
ここは気になるので、後日修正する

- view
トップページにお気に入り店舗とフォローしているユーザー表示
ヘッダーのメニューよりフォロワーの一覧が表示できる
店舗もフォローユーザーも削除できる
しかし削除するたびに詳細ページに行くので後日修正する（修正方法が分からなかった）
お気に入り数検索を追加

# 画面レイアウト
- トップページ
![image](https://user-images.githubusercontent.com/87374457/139572925-32fdd4e3-b30c-479c-b1ca-d33ffc018cfb.png)

- お気に入り店舗一覧
![image](https://user-images.githubusercontent.com/87374457/139572946-c748932f-3a58-4d26-bd21-fd0a7a37a66e.png)

- フォローユーザー一覧
![image](https://user-images.githubusercontent.com/87374457/139572959-acc845f7-b2b5-4ac5-93a6-600d11c4fc5e.png)

- フォロワー一覧
![image](https://user-images.githubusercontent.com/87374457/139572965-145e23e1-a483-465e-879a-2cef826e0109.png)

# 検証内容
## お気に入り、フォロー
- [x] トップページにお気に入り登録した店舗は表示されるか
- [x] トップページからお気に入り登録した店舗の一覧が表示できるか
- [x] トップページからお気に入り登録した店舗の詳細ページが表示できるか
- [x] トップページにフォローユーザーは表示されるか
- [x] トップページからフォローユーザーの一覧が表示できるか
- [x] トップページからフォローユーザーの詳細ページが表示できるか
- [x] 店舗詳細ページからお気に入り登録ができるか
- [x] 店舗詳細ページからお気に入り登録の解除ができるか
- [x] お気に入り登録した店舗一覧ページからお気に入り登録の解除ができるか
- [x] 店舗詳細ページにお気に入された数、お気に入り登録されたユーザーは表示されているか
- [x] ユーザー詳細ページにお気に入り数、お気に入り登録した店舗は表示されているか
- [x] ユーザー詳細ページからフォローできるか
- [x] ユーザー詳細ページからフォロー解除できるか
- [x] フォロー一覧からフォロー解除できるか
- [x] ユーザー詳細ページにフォロワー数は表示されているか
- [x]  ヘッダーメニューからフォロワー一覧が表示できるか

## お気に入り数検索
- [x] お気に入り数から検索できるか

|お気に入り数 | 以上以下判定 |
|---|---|
|1|以上|
|1|以下|
|0|以上|
|0|以上|
|-1|以上|
|-1|以下|