### PR TITLE
エリアを追加

### DIFF
--- a/app/assets/javascripts/dashboard/municipalities.coffee
+++ b/app/assets/javascripts/dashboard/municipalities.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/javascripts/dashboard/prefectures.coffee
+++ b/app/assets/javascripts/dashboard/prefectures.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/dashboard/municipalities.scss
+++ b/app/assets/stylesheets/dashboard/municipalities.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the dashboard/municipalities controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/dashboard/prefectures.scss
+++ b/app/assets/stylesheets/dashboard/prefectures.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the dashboard/prefectures controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/coffee_shops_controller.rb
+++ b/app/controllers/coffee_shops_controller.rb
@@ -77,6 +77,7 @@ class CoffeeShopsController < ApplicationController
       hash[:review_count_search_type] = params[:review_count_search_type]
       hash[:favorite_count] = params[:favorite_count]
       hash[:favorite_count_search_type] = params[:favorite_count_search_type]
+      hash[:municipality_id] = params[:municipality_id]
       hash
     end
     
@@ -104,5 +105,7 @@ class CoffeeShopsController < ApplicationController
         @coffee_shop_search_conditions << "お気に入り数検索：#{params[:favorite_count]}件以上" if params[:favorite_count_search_type].eql?("more_than")
         @coffee_shop_search_conditions << "お気に入り数検索：#{params[:favorite_count]}件以下" if params[:favorite_count_search_type].eql?("less_than")
       end
+      @coffee_shop_search_conditions << "エリア：#{Municipality.find(params[:municipality_id]).name}" if params[:municipality_id].present?
+      
     end
 end

--- a/app/controllers/dashboard/coffee_shops_controller.rb
+++ b/app/controllers/dashboard/coffee_shops_controller.rb
@@ -19,6 +19,7 @@ class Dashboard::CoffeeShopsController < ApplicationController
   def new
     @coffee_shop = CoffeeShop.new
     @search_categories = SearchCategory.all
+    set_municipality_tags
   end
 
   def create
@@ -32,6 +33,7 @@ class Dashboard::CoffeeShopsController < ApplicationController
   end
 
   def edit
+    set_municipality_tags
   end
 
   def update
@@ -49,11 +51,19 @@ class Dashboard::CoffeeShopsController < ApplicationController
   end
   
   private
-    def set_coffee_shop
-      @coffee_shop = CoffeeShop.find(params[:id])
-    end
+  def set_coffee_shop
+    @coffee_shop = CoffeeShop.find(params[:id])
+  end
     
-    def coffee_shop_params
-      params.require(:coffee_shop).permit(:name, :shop_url, :address, :tell, :access, :business_start_hour, :business_end_hour, :regular_holiday, :instagram_url, :instagram_spot_url, :municipalitie_id, {:search_category_ids => []}, images: [])
+  def set_municipality_tags
+    municipalities = Municipality.all
+    @municipality_tags = []
+    municipalities.each do |municipality|
+      @municipality_tags << [municipality.name, municipality.id]
     end
+  end
+  
+  def coffee_shop_params
+    params.require(:coffee_shop).permit(:name, :shop_url, :address, :tell, :access, :business_start_hour, :business_end_hour, :regular_holiday, :instagram_url, :instagram_spot_url, :municipalitie_id, {:search_category_ids => []}, images: [])
+  end
 end

--- a/app/controllers/dashboard/municipalities_controller.rb
+++ b/app/controllers/dashboard/municipalities_controller.rb
@@ -1,0 +1,51 @@
+class Dashboard::MunicipalitiesController < ApplicationController
+  before_action :set_municipality, only: %w[edit update destroy]
+  before_action :set_prefecture_tags, only: %w[index edit]
+  layout "dashboard/dashboard"
+  
+  def index
+    @municipalities = Municipality.all
+    @municipality = Municipality.new
+  end
+  
+  def show
+  end
+  
+  def create
+    @municipality = Municipality.new(municipality_params)
+    @municipality.save
+    redirect_to dashboard_municipalities_path
+  end
+  
+  def edit
+  end
+  
+  def update
+    @municipality.update(municipality_params)
+    redirect_to dashboard_municipalities_path
+  end
+  
+  def destroy
+    @municipality.destroy
+    redirect_to dashboard_municipalities_path
+  end
+  
+  private
+  
+  def set_municipality
+    @municipality = Municipality.find(params[:id])
+  end
+  
+  def set_prefecture_tags
+    prefectures = Prefecture.all
+    @prefecture_tag = []
+    prefectures.each do |prefecture|
+      @prefecture_tag << [prefecture.name, prefecture.id]
+    end
+  end
+  
+  def municipality_params
+    params.require(:municipality).permit(:name, :prefecture_id)
+  end
+
+end

--- a/app/controllers/dashboard/prefectures_controller.rb
+++ b/app/controllers/dashboard/prefectures_controller.rb
@@ -7,6 +7,9 @@ class Dashboard::PrefecturesController < ApplicationController
     @prefecture = Prefecture.new
   end
   
+  def show
+  end
+  
   def create
     @prefecture = Prefecture.new(prefecture_params)
     @prefecture.save

--- a/app/controllers/dashboard/prefectures_controller.rb
+++ b/app/controllers/dashboard/prefectures_controller.rb
@@ -1,0 +1,39 @@
+class Dashboard::PrefecturesController < ApplicationController
+  before_action :set_prefecture, only: %w[edit update destroy]
+  layout "dashboard/dashboard"
+  
+  def index
+    @prefectures = Prefecture.all
+    @prefecture = Prefecture.new
+  end
+  
+  def create
+    @prefecture = Prefecture.new(prefecture_params)
+    @prefecture.save
+    redirect_to dashboard_prefectures_path
+  end
+  
+  def edit
+  end
+  
+  def update
+    @prefecture.update(prefecture_params)
+    redirect_to dashboard_prefectures_path
+  end
+  
+  def destroy
+    @prefecture.destroy
+    redirect_to dashboard_prefectures_path
+  end
+  
+  private
+  
+  def set_prefecture
+    @prefecture = Prefecture.find(params[:id])
+  end
+  
+  def prefecture_params
+    params.require(:prefecture).permit(:name)
+  end
+  
+end

--- a/app/controllers/web_controller.rb
+++ b/app/controllers/web_controller.rb
@@ -1,4 +1,8 @@
 class WebController < ApplicationController
   def index
   end
+  
+  def search
+    @municipalities = Municipality.where(prefecture_id: params[:prefecture_id])
+  end
 end

--- a/app/helpers/dashboard/municipalities_helper.rb
+++ b/app/helpers/dashboard/municipalities_helper.rb
@@ -1,0 +1,2 @@
+module Dashboard::MunicipalitiesHelper
+end

--- a/app/helpers/dashboard/prefectures_helper.rb
+++ b/app/helpers/dashboard/prefectures_helper.rb
@@ -1,0 +1,2 @@
+module Dashboard::PrefecturesHelper
+end

--- a/app/models/coffee_shop.rb
+++ b/app/models/coffee_shop.rb
@@ -8,7 +8,7 @@ class CoffeeShop < ApplicationRecord
 	
 	# バリデーション
 	# 必ず登録してほしい項目
-	validates :name, :address, :tell, presence: true
+	validates :name, :address, :tell, :municipalitie_id, presence: true
 	
 	# 重複チェック
 	validates :tell, uniqueness: true

--- a/app/models/municipality.rb
+++ b/app/models/municipality.rb
@@ -1,0 +1,5 @@
+class Municipality < ApplicationRecord
+  belongs_to :prefecture
+  
+  validates :name, :prefecture_id, presence: true
+end

--- a/app/models/prefecture.rb
+++ b/app/models/prefecture.rb
@@ -1,0 +1,5 @@
+class Prefecture < ApplicationRecord
+  has_many :municipalities
+  
+  validates :name, presence: true
+end

--- a/app/service/coffee_shop_search_service.rb
+++ b/app/service/coffee_shop_search_service.rb
@@ -9,6 +9,7 @@ class CoffeeShopSearchService
     @review_count_search_type = hash[:review_count_search_type]
     @favorite_count = hash[:favorite_count]
     @favorite_count_search_type = hash[:favorite_count_search_type]
+    @municipality_id = hash[:municipality_id]
   end
   
   def search
@@ -31,6 +32,9 @@ class CoffeeShopSearchService
     
     # お気に入り数検索
     search_by_favorite_count if @favorite_count.present?
+    
+    # エリア検索
+    search_by_municipality_id if @municipality_id.present?
     
     @coffee_shops
   end
@@ -117,6 +121,11 @@ class CoffeeShopSearchService
     end
     # 条件にあう店舗を取得
     @coffee_shops = @coffee_shops.where(id: coffee_shop_ids)
+  end
+  
+  # エリア検索
+  def search_by_municipality_id
+    @coffee_shops = @coffee_shops.where(municipalitie_id: @municipality_id)
   end
   
 end

--- a/app/views/coffee_shops/show.html.erb
+++ b/app/views/coffee_shops/show.html.erb
@@ -38,7 +38,7 @@
   <br>
   InstagramスポットURL：<%= @coffee_shop.instagram_spot_url %>
   <br>
-  エリアid：<%= @coffee_shop.municipalitie_id %>
+  エリア：<%= Municipality.find(@coffee_shop.municipalitie_id).name %>
 	<hr>
 	レビュー数：<%= @reviews.count %>
 	<hr>

--- a/app/views/dashboard/coffee_shops/edit.html.erb
+++ b/app/views/dashboard/coffee_shops/edit.html.erb
@@ -21,7 +21,7 @@
   <br>
   InstagramスポットURL<%= f.text_field :instagram_spot_url %>
   <br>
-  エリアid<%= f.number_field :municipalitie_id %>
+  エリア<%= f.select :municipalitie_id, @municipality_tags %>
   <br>
   <div class="form-inline mt-4 mb-4 row">
     <%= f.label "画像" %>

--- a/app/views/dashboard/coffee_shops/edit.html.erb
+++ b/app/views/dashboard/coffee_shops/edit.html.erb
@@ -21,7 +21,7 @@
   <br>
   InstagramスポットURL<%= f.text_field :instagram_spot_url %>
   <br>
-  エリア<%= f.select :municipalitie_id, @municipality_tags %>
+  エリア<%= f.select :municipalitie_id, @municipality_tags, { include_blank: '選択してください' } %>
   <br>
   <div class="form-inline mt-4 mb-4 row">
     <%= f.label "画像" %>

--- a/app/views/dashboard/coffee_shops/new.html.erb
+++ b/app/views/dashboard/coffee_shops/new.html.erb
@@ -1,13 +1,13 @@
 <h1>店舗追加</h1>
 
 <%= form_with model: @coffee_shop, url: dashboard_coffee_shops_path, local: true do |f| %>
-  店舗名<%= f.text_field :name %>
+  ※店舗名<%= f.text_field :name %>
   <br>
   店舗HP<%= f.text_field :shop_url %>
   <br>
-  住所<%= f.text_field :address %>
+  ※住所<%= f.text_field :address %>
   <br>
-  電話番号<%= f.number_field :tell %>
+  ※電話番号<%= f.number_field :tell %>
   <br>
   アクセス<%= f.text_field :access %>
   <br>
@@ -21,7 +21,7 @@
   <br>
   InstagramスポットURL<%= f.text_field :instagram_spot_url %>
   <br>
-  エリア<%= f.select :municipalitie_id, @municipality_tags %>
+  ※エリア<%= f.select :municipalitie_id, @municipality_tags, { include_blank: '選択してください' } %>
   <br>
   <div class="form-inline mt-4 mb-4 row">
     <div class="d-flex flex-column ml-2">

--- a/app/views/dashboard/coffee_shops/new.html.erb
+++ b/app/views/dashboard/coffee_shops/new.html.erb
@@ -21,7 +21,7 @@
   <br>
   InstagramスポットURL<%= f.text_field :instagram_spot_url %>
   <br>
-  エリアid<%= f.number_field :municipalitie_id %>
+  エリア<%= f.select :municipalitie_id, @municipality_tags %>
   <br>
   <div class="form-inline mt-4 mb-4 row">
     <div class="d-flex flex-column ml-2">

--- a/app/views/dashboard/municipalities/edit.html.erb
+++ b/app/views/dashboard/municipalities/edit.html.erb
@@ -1,0 +1,12 @@
+<h1>カテゴリ編集</h1>
+
+<%= form_with model: @municipality, url: dashboard_municipality_path(@municipality), local: true do |f| %>
+  <%= f.label :name, "エリア名称" %>
+  <%= f.text_field :name %>
+  
+  <%= f.label :prefecture_id, "都道府県" %>
+  <%= f.select :prefecture_id, @prefecture_tag %>
+  
+  <%= f.submit "更新" %>
+<% end %>
+<%= link_to "カテゴリ一覧に戻る", dashboard_municipalities_path %>

--- a/app/views/dashboard/municipalities/index.html.erb
+++ b/app/views/dashboard/municipalities/index.html.erb
@@ -1,0 +1,41 @@
+<div class="w-75">
+  
+  <h1>エリア一覧</h1>
+  
+  <%= form_with(model: @municipality, url: dashboard_municipalities_path, local: true) do |f| %>
+    <%= f.label :name, "エリア名称" %>
+    <%= f.text_field :name %>
+    <br>
+    <%= f.label :prefecture_id, "都道府県" %>
+    <%= f.select :prefecture_id, @prefecture_tag %>
+    <%= f.submit "新規作成" %>
+  <% end %>
+  
+  <table class="table mt-5">
+    <thead>
+      <tr>
+        <th scope="col" class="w-25">ID</th>
+        <th scope="col">エリア名称</th>
+        <th scope="col">都道府県</th>
+        <th scope="col"></th>
+        <th scope="col"></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @municipalities.each do |municipality| %>
+      <tr>
+        <td scope="row"><%= municipality.id %></td>
+        <td><%= municipality.name %></td>
+        <td><%= municipality.prefecture.name %></td>
+        <td>
+          <%= link_to "編集", edit_dashboard_municipality_path(municipality) %>
+          
+        </td>
+        <td>
+          <%= link_to "削除", dashboard_municipality_path(municipality), method: :delete, data: { confirm: 'Are you sure?' } %>
+        </td>
+      </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/dashboard/prefectures/edit.html.erb
+++ b/app/views/dashboard/prefectures/edit.html.erb
@@ -1,0 +1,8 @@
+<h1>都道府県名編集</h1>
+<%= form_with model: @prefecture, url: dashboard_prefecture_path(@prefecture), local: true do |f| %>
+  <%= f.label :name, "都道府県名" %>
+  <%= f.text_field :name %>
+  
+  <%= f.submit "更新" %>
+<% end %>
+<%= link_to "都道府県一覧に戻る", dashboard_prefectures_path %>

--- a/app/views/dashboard/prefectures/index.html.erb
+++ b/app/views/dashboard/prefectures/index.html.erb
@@ -1,0 +1,37 @@
+<div class="w-75">
+  
+  <h1>都道府県一覧</h1>
+  
+  <%= form_with(model: @prefecture, url: dashboard_prefectures_path, local: true) do |f| %>
+    <%= f.label :name, "都道府県名" %>
+    <%= f.text_field :name %>
+    
+    <%= f.submit "新規作成" %>
+  <% end %>
+  
+  <table class="table mt-5">
+    <thead>
+      <tr>
+        <th scope="col" class="w-25">ID</th>
+        <th scope="col">都道府県</th>
+        <th scope="col"></th>
+        <th scope="col"></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @prefectures.each do |prefecture| %>
+      <tr>
+        <td scope="row"><%= prefecture.id %></td>
+        <td><%= prefecture.name %></td>
+        <td>
+          <%= link_to "編集", edit_dashboard_prefecture_path(prefecture) %>
+          
+        </td>
+        <td>
+          <%= link_to "削除", dashboard_prefecture_path(prefecture), method: :delete, data: { confirm: '本当に?' } %>
+        </td>
+      </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/layouts/dashboard/_sidebar.html.erb
+++ b/app/views/layouts/dashboard/_sidebar.html.erb
@@ -9,5 +9,9 @@
   <br>
   <b>検索条件管理</b>
   <br>
+    <%= link_to "都道府県一覧", dashboard_prefectures_path %>
+  <br>
+    <%= link_to "エリア一覧", dashboard_municipalities_path %>
+  <br>
     <%= link_to "カテゴリ一覧", dashboard_search_categories_path %>
 </div>

--- a/app/views/web/index.html.erb
+++ b/app/views/web/index.html.erb
@@ -30,52 +30,60 @@
   <hr>
   
   <div class="search_by_area">
-    (検索のエリア)
-    <%= form_with url: search_coffee_shops_path, method: :get, local: true do |f| %>
-      店舗名
-      <br>
-      <%= f.text_field :name %>
+    (検索のエリア)<br>
+    都道府県
+    <br>
+    <% Prefecture.all.each do |prefecture| %>
+      <%= link_to prefecture.name, search_path(prefecture_id: prefecture.id) %>
+    <% end %>
     
     <hr>
-      電話番号検索
-      <br>
-      <%= f.number_field :tell %>
-    <hr>
-      こだわり検索
-      <br>
-      <div class="check_box">
-        <%= f.collection_check_boxes(:search_category_ids, SearchCategory.all, :id, :name, {include_hidden: false}) do |b| %>
-          <%= b.label { b.check_box + b.text } %>
-        <% end %>
-      </div>
-    <hr>
-      レビュー点数検索
-      <br>
-      <%= f.number_field :review_score %>
-      <%= f.radio_button :review_score_search_type, :more_than, {:checked => true} %>
-      <%= f.label :review_score_search_type, "以上", {value: :more_than, stylr: "display: inline-block;"} %>
-      <%= f.radio_button :review_score_search_type, :less_than %>
-      <%= f.label :review_score_search_type, "以下", {value: :less_than, style: "display: inline-block;"} %>
-    <hr>
-      レビュー数検索 ※0で検索すると未レビューのお店のみ表示します。
-      <br>
-      <%= f.number_field :review_count %>
-      <%= f.radio_button :review_count_search_type, :more_than, {:checked => true} %>
-      <%= f.label :review_count_search_type, "以上", {value: :more_than, style: "display: inline-block;"} %>
-      <%= f.radio_button :review_count_search_type, :less_than %>
-      <%= f.label :review_count_search_type, "以下", {value: :less_than, style: "display: inline-block;"} %>
-    <hr>
-      お気に入り数検索　※0で検索するとお気に入り数0のお店のみ表示します。
-      <br>
-      <%= f.number_field :favorite_count %>
-      <%= f.radio_button :favorite_count_search_type, :more_than, {:checked => true} %>
-      <%= f.label :favorite_count_search_type, "以上", {value: :more_than, style: "display: inline-block;"} %>
-      <%= f.radio_button :favorite_count_search_type, :less_than %>
-      <%= f.label :favorite_count_search_type, "以下", {value: :less_than, style: "display: inline-block;"} %>
-    <hr>
-      <%= f.submit :search %>
-    <% end %> 
-  </div>
+    
+  <!--  <%= form_with url: search_coffee_shops_path, method: :get, local: true do |f| %>-->
+  <!--    店舗名-->
+  <!--    <br>-->
+  <!--    <%= f.text_field :name %>-->
+    
+  <!--  <hr>-->
+  <!--    電話番号検索-->
+  <!--    <br>-->
+  <!--    <%= f.number_field :tell %>-->
+  <!--  <hr>-->
+  <!--    こだわり検索-->
+  <!--    <br>-->
+  <!--    <div class="check_box">-->
+  <!--      <%= f.collection_check_boxes(:search_category_ids, SearchCategory.all, :id, :name, {include_hidden: false}) do |b| %>-->
+  <!--        <%= b.label { b.check_box + b.text } %>-->
+  <!--      <% end %>-->
+  <!--    </div>-->
+  <!--  <hr>-->
+  <!--    レビュー点数検索-->
+  <!--    <br>-->
+  <!--    <%= f.number_field :review_score %>-->
+  <!--    <%= f.radio_button :review_score_search_type, :more_than, {:checked => true} %>-->
+  <!--    <%= f.label :review_score_search_type, "以上", {value: :more_than, stylr: "display: inline-block;"} %>-->
+  <!--    <%= f.radio_button :review_score_search_type, :less_than %>-->
+  <!--    <%= f.label :review_score_search_type, "以下", {value: :less_than, style: "display: inline-block;"} %>-->
+  <!--  <hr>-->
+  <!--    レビュー数検索 ※0で検索すると未レビューのお店のみ表示します。-->
+  <!--    <br>-->
+  <!--    <%= f.number_field :review_count %>-->
+  <!--    <%= f.radio_button :review_count_search_type, :more_than, {:checked => true} %>-->
+  <!--    <%= f.label :review_count_search_type, "以上", {value: :more_than, style: "display: inline-block;"} %>-->
+  <!--    <%= f.radio_button :review_count_search_type, :less_than %>-->
+  <!--    <%= f.label :review_count_search_type, "以下", {value: :less_than, style: "display: inline-block;"} %>-->
+  <!--  <hr>-->
+  <!--    お気に入り数検索　※0で検索するとお気に入り数0のお店のみ表示します。-->
+  <!--    <br>-->
+  <!--    <%= f.number_field :favorite_count %>-->
+  <!--    <%= f.radio_button :favorite_count_search_type, :more_than, {:checked => true} %>-->
+  <!--    <%= f.label :favorite_count_search_type, "以上", {value: :more_than, style: "display: inline-block;"} %>-->
+  <!--    <%= f.radio_button :favorite_count_search_type, :less_than %>-->
+  <!--    <%= f.label :favorite_count_search_type, "以下", {value: :less_than, style: "display: inline-block;"} %>-->
+  <!--  <hr>-->
+  <!--    <%= f.submit :search %>-->
+  <!--  <% end %> -->
+  <!--</div>-->
   
   <hr>
   

--- a/app/views/web/search.html.erb
+++ b/app/views/web/search.html.erb
@@ -1,0 +1,55 @@
+<h1>検索</h1>
+
+<%= form_with url: search_coffee_shops_path, method: :get, local: true do |f| %>
+  エリア
+  <br>
+  <% @municipalities.each do |municipality| %>
+    <%= f.radio_button :municipality_id, municipality.id %>
+    <%= f.label :municipality_id, municipality.name, {value: municipality.id, stylr: "display: inline-block;"} %>
+  <% end %> 
+    
+<hr>
+    
+  店舗名
+  <br>
+  <%= f.text_field :name %>
+
+<hr>
+  電話番号検索
+  <br>
+  <%= f.number_field :tell %>
+<hr>
+  こだわり検索
+  <br>
+  <div class="check_box">
+    <%= f.collection_check_boxes(:search_category_ids, SearchCategory.all, :id, :name, {include_hidden: false}) do |b| %>
+      <%= b.label { b.check_box + b.text } %>
+    <% end %>
+  </div>
+<hr>
+  レビュー点数検索
+  <br>
+  <%= f.number_field :review_score %>
+  <%= f.radio_button :review_score_search_type, :more_than, {:checked => true} %>
+  <%= f.label :review_score_search_type, "以上", {value: :more_than, stylr: "display: inline-block;"} %>
+  <%= f.radio_button :review_score_search_type, :less_than %>
+  <%= f.label :review_score_search_type, "以下", {value: :less_than, style: "display: inline-block;"} %>
+<hr>
+  レビュー数検索 ※0で検索すると未レビューのお店のみ表示します。
+  <br>
+  <%= f.number_field :review_count %>
+  <%= f.radio_button :review_count_search_type, :more_than, {:checked => true} %>
+  <%= f.label :review_count_search_type, "以上", {value: :more_than, style: "display: inline-block;"} %>
+  <%= f.radio_button :review_count_search_type, :less_than %>
+  <%= f.label :review_count_search_type, "以下", {value: :less_than, style: "display: inline-block;"} %>
+<hr>
+  お気に入り数検索　※0で検索するとお気に入り数0のお店のみ表示します。
+  <br>
+  <%= f.number_field :favorite_count %>
+  <%= f.radio_button :favorite_count_search_type, :more_than, {:checked => true} %>
+  <%= f.label :favorite_count_search_type, "以上", {value: :more_than, style: "display: inline-block;"} %>
+  <%= f.radio_button :favorite_count_search_type, :less_than %>
+  <%= f.label :favorite_count_search_type, "以下", {value: :less_than, style: "display: inline-block;"} %>
+<hr>
+  <%= f.submit :search %>
+<% end %> 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,8 @@ Rails.application.routes.draw do
     resources :users, only: [:index, :destroy]
     resources :coffee_shops, except: [:show]
     resources :search_categories, except: [:new]
+    resources :prefectures, except: [:new]
+    resources :municipalities, except: [:new]
   end
   
   devise_for :users, :controllers => {
@@ -49,7 +51,5 @@ Rails.application.routes.draw do
       get :follow
     end
   end
-  
-  # get '/users/:id', to: 'users#show'
   
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   get "dashboard", :to => "dashboard#index"
+  get "search", :to => "web#search"
   
   resources :coffee_shops do
     member do 

--- a/db/migrate/20211106072905_create_prefectures.rb
+++ b/db/migrate/20211106072905_create_prefectures.rb
@@ -1,0 +1,8 @@
+class CreatePrefectures < ActiveRecord::Migration[5.2]
+  def change
+    create_table :prefectures do |t|
+      t.string :name
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20211106073134_create_municipalities.rb
+++ b/db/migrate/20211106073134_create_municipalities.rb
@@ -1,0 +1,9 @@
+class CreateMunicipalities < ActiveRecord::Migration[5.2]
+  def change
+    create_table :municipalities do |t|
+      t.string :name
+      t.integer :prefecture_id
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_02_114620) do
+ActiveRecord::Schema.define(version: 2021_11_06_073134) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -87,6 +87,19 @@ ActiveRecord::Schema.define(version: 2021_11_02_114620) do
     t.datetime "created_at"
     t.index ["mentionable_id", "mentionable_type"], name: "fk_mentionables"
     t.index ["mentioner_id", "mentioner_type"], name: "fk_mentions"
+  end
+
+  create_table "municipalities", force: :cascade do |t|
+    t.string "name"
+    t.integer "prefecture_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "prefectures", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "reviews", force: :cascade do |t|

--- a/test/controllers/dashboard/municipalities_controller_test.rb
+++ b/test/controllers/dashboard/municipalities_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class Dashboard::MunicipalitiesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/controllers/dashboard/prefectures_controller_test.rb
+++ b/test/controllers/dashboard/prefectures_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class Dashboard::PrefecturesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/municipalities.yml
+++ b/test/fixtures/municipalities.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/prefectures.yml
+++ b/test/fixtures/prefectures.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/municipality_test.rb
+++ b/test/models/municipality_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class MunicipalityTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/prefecture_test.rb
+++ b/test/models/prefecture_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class PrefectureTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# 背景
- この機能が必要な理由
場所から店舗を検索できるようにするため

- どういう機能なのか
エリアを店舗情報に登録し、エリアを条件に検索を行う

- なぜこのPR単位なのか
エリアの登録、編集、削除、店舗情報にエリアを追加、エリア検索機能はエリア情報をもとに行うため、
一つのＰＲ単位にまとめた

# やったこと
## コードベース
- 設計方針
  - エリアの登録
都道府県とそれぞれに含まれるエリア(市町村)を管理画面から作成できる。
地名が変更されることはほぼほぼないと思われるが、念のため編集等を行えるようにする

  - エリア検索
都道府県選択後に検索条件登録ページにいどうするように変更
エリア検索以外にも合わせて、店舗名などの検索も検索条件登録ページで行う

- model
都道府県`prefectures`、市町村`municipalities`を作成
複数の市町村を都道府県が持つ構造
検索用サービスモデルにエリア検索も追加

- controller
都道府県と市町村のコントローラを作成
管理画面でか登録等は行わないので、dashboardフォルダ内のみ

- view
検索条件を選択するための画面を追加
トップページからくるのでwebフォルダに作成

# 画面レイアウト　※のちのち修正する
- 都道府県一覧
![image](https://user-images.githubusercontent.com/87374457/140635871-973ae577-096c-4c56-a4ee-5d5218f1578b.png)

- エリア一覧
![image](https://user-images.githubusercontent.com/87374457/140635885-fc09df33-9920-4d1a-b2a4-e7187515a8da.png)

- 検索条件
![image](https://user-images.githubusercontent.com/87374457/140635910-de10c328-0b4d-4ed9-8ac6-87f87eafac5e.png)

# 検証内容
- [x] 都道府県の登録はできるか
- [x] 都道府県の編集はできるか
- [x] 都道府県の削除はできるか
- [x] エリアの登録はできるか
- [x] エリアの編集はできるか
- [x] エリアの削除はできるか
- [x] 登録されている都道府県がトップページに表示されているか
- [x] 選択した都道府県のエリアが検索ページに表示されているか
- [x] エリア検索ができるか
- [x] 店舗情報のエリアが登録できるか
- [x] 店舗情報のエリアが編集できるか
- [x] 店舗詳細にエリアが表示されているか

※備考
コーヒーショップテーブルの市町村のカラム名が変なので後々修正が必要
`municipalitie_id`　→　`municipality_id`