### PR TITLE
店舗登録機能を修正

### DIFF
--- a/app/controllers/dashboard/coffee_shops_controller.rb
+++ b/app/controllers/dashboard/coffee_shops_controller.rb
@@ -24,7 +24,6 @@ class Dashboard::CoffeeShopsController < ApplicationController
 
   def create
     @coffee_shop = CoffeeShop.new(coffee_shop_params)
-    binding.pry
     if @coffee_shop.save
       redirect_to dashboard_coffee_shops_path, notice: '登録完了'
     else
@@ -38,6 +37,12 @@ class Dashboard::CoffeeShopsController < ApplicationController
   end
 
   def update
+    @regular_holiday = ""
+    params[:youbi].each do |regular_holiday|
+      if regular_holiday.second == "1"
+        @regular_holiday << regular_holiday.first
+      end
+    end
     if @coffee_shop.update(coffee_shop_params)
       redirect_to dashboard_coffee_shops_url, notice: '登録完了'
     else

--- a/app/controllers/dashboard/coffee_shops_controller.rb
+++ b/app/controllers/dashboard/coffee_shops_controller.rb
@@ -24,6 +24,7 @@ class Dashboard::CoffeeShopsController < ApplicationController
 
   def create
     @coffee_shop = CoffeeShop.new(coffee_shop_params)
+    binding.pry
     if @coffee_shop.save
       redirect_to dashboard_coffee_shops_path, notice: '登録完了'
     else

--- a/app/models/coffee_shop.rb
+++ b/app/models/coffee_shop.rb
@@ -14,7 +14,7 @@ class CoffeeShop < ApplicationRecord
 	validates :tell, uniqueness: true
 	
 	# 電話番号チェック
-	validates :tell, format: { with: /\A\d{10,11}\z/ }
+	validates :tell, presence: true, format: { with: /\A\d{10}$|^\d{11}\z/ }
 	validates :tell, numericality: true
 	
 	# 時間チェック
@@ -26,8 +26,6 @@ class CoffeeShop < ApplicationRecord
 	validates :address, length: { maximum: 300}
 	validates :tell, length: { maximum: 11}
 	validates :access, length: { maximum: 100}
-	validates :business_start_hour, length: { maximum: 6}
-	validates :business_end_hour, length: { maximum: 6}
 	validates :regular_holiday, length: { maximum: 14}
 	validates :instagram_url, length: { maximum: 2048}
 	validates :instagram_spot_url, length: { maximum: 2048}

--- a/app/models/coffee_shop.rb
+++ b/app/models/coffee_shop.rb
@@ -1,7 +1,8 @@
 class CoffeeShop < ApplicationRecord
 	has_many :coffee_shop_search_categories, dependent: :destroy
 	has_many :search_categories, :through => :coffee_shop_search_categories
-	has_many :reviews
+	has_many :reviews, dependent: :destroy
+	
 	accepts_nested_attributes_for :coffee_shop_search_categories, allow_destroy: true
 	acts_as_likeable
 	has_many_attached :images
@@ -14,7 +15,9 @@ class CoffeeShop < ApplicationRecord
 	validates :tell, uniqueness: true
 	
 	# 電話番号チェック
-	validates :tell, presence: true, format: { with: /\A\d{10}$|^\d{11}\z/ }
+	# validates :tell, presence: true, format: { with: /\A\d{10}$|^\d{11}\z/ }
+	validates :tell, presence: true, format: { with: /\A\d{10,11}\z/ }
+	
 	validates :tell, numericality: true
 	
 	# 時間チェック

--- a/app/views/dashboard/coffee_shops/edit.html.erb
+++ b/app/views/dashboard/coffee_shops/edit.html.erb
@@ -15,7 +15,11 @@
   <br>
   営業終了時間<%= f.time_field :business_end_hour %>
   <br>
-  定休日<%= f.text_field :regular_holiday %>
+  定休日
+  <% %w(月 火 水 木 金 土 日 不定休).each do |ingredient| %>
+    <%= check_box :youbi, ingredient %>
+    <%= ingredient %>
+  <% end %>
   <br>
   Instagram公式URL<%= f.text_field :instagram_url %>
   <br>

--- a/app/views/dashboard/coffee_shops/new.html.erb
+++ b/app/views/dashboard/coffee_shops/new.html.erb
@@ -15,7 +15,11 @@
   <br>
   営業終了時間<%= f.time_field :business_end_hour %>
   <br>
-  定休日<%= f.text_field :regular_holiday %>
+  定休日
+  <% %w(月 火 水 木 金 土 日 不定休).each do |ingredient| %>
+    <%= check_box :regular_holiday, ingredient %>
+    <%= ingredient %>
+  <% end %>
   <br>
   Instagram公式URL<%= f.text_field :instagram_url %>
   <br>
@@ -24,6 +28,12 @@
   ※エリア<%= f.select :municipalitie_id, @municipality_tags, { include_blank: '選択してください' } %>
   <br>
   <div class="form-inline mt-4 mb-4 row">
+    <%= f.label "画像" %>
+    <% if @coffee_shop.images.attached? %>
+      <% @coffee_shop.images.each do |image| %>
+        <%= image_tag image, size: "100x100" %>
+      <% end %>
+    <% end %>
     <div class="d-flex flex-column ml-2">
       <small class="mb-3">600px×600px推奨。<br>画像をアップロードして下さい。</small>
       <%= f.label "画像を選択" %>


### PR DESCRIPTION
# 背景
- 正しい店舗で登録ができなかったので修正
- まず登録できるところは完了させて、今後の検証の際にエラーが発生するのを防ぐ。
- 定休日をチェックボックスから値を取得し、登録したかったがうまくいかなかったので、後日修正を行う

# やったこと
- 電話番号の正規表現を修正
- 営業時間の桁数が間違っていたので削除
time型で登録すると、内部的には`2000-01-01 12:00:00 UTC`のように格納されるらしく、6桁だとエラーで登録できなかったため