### PR TITLE
ランキング機能の追加

### DIFF
--- a/app/controllers/web_controller.rb
+++ b/app/controllers/web_controller.rb
@@ -1,5 +1,8 @@
 class WebController < ApplicationController
   def index
+    @rank_favorite_coffee_shops = CoffeeShop.find(CoffeeShop.all.order('likers_count desc').limit(5).pluck(:id))
+    @rank_follow_users = User.find(User.all.order('followers_count desc').limit(5).pluck(:id))
+    @rank_review_users = User.find(Review.group(:user_id).order('count(user_id)desc').limit(5).pluck(:user_id))
   end
   
   def search

--- a/app/views/coffee_shops/show.html.erb
+++ b/app/views/coffee_shops/show.html.erb
@@ -3,7 +3,7 @@
 		<i class="fa fa-heart"></i><%= current_user.likes?(@coffee_shop) ? "お気に入り解除" : "お気に入り" %>
 	<% end %>
 	<br>
-	お気に入り数：<%= @likers.count %>
+	お気に入り数：<%= @coffee_shop.likers_count %>
 	<br>
 	お気に入りユーザー：
 	<% @likers.last(5).each do |liker| %>

--- a/app/views/web/index.html.erb
+++ b/app/views/web/index.html.erb
@@ -36,59 +36,31 @@
     <% Prefecture.all.each do |prefecture| %>
       <%= link_to prefecture.name, search_path(prefecture_id: prefecture.id) %>
     <% end %>
-    
-    <hr>
-    
-  <!--  <%= form_with url: search_coffee_shops_path, method: :get, local: true do |f| %>-->
-  <!--    店舗名-->
-  <!--    <br>-->
-  <!--    <%= f.text_field :name %>-->
-    
-  <!--  <hr>-->
-  <!--    電話番号検索-->
-  <!--    <br>-->
-  <!--    <%= f.number_field :tell %>-->
-  <!--  <hr>-->
-  <!--    こだわり検索-->
-  <!--    <br>-->
-  <!--    <div class="check_box">-->
-  <!--      <%= f.collection_check_boxes(:search_category_ids, SearchCategory.all, :id, :name, {include_hidden: false}) do |b| %>-->
-  <!--        <%= b.label { b.check_box + b.text } %>-->
-  <!--      <% end %>-->
-  <!--    </div>-->
-  <!--  <hr>-->
-  <!--    レビュー点数検索-->
-  <!--    <br>-->
-  <!--    <%= f.number_field :review_score %>-->
-  <!--    <%= f.radio_button :review_score_search_type, :more_than, {:checked => true} %>-->
-  <!--    <%= f.label :review_score_search_type, "以上", {value: :more_than, stylr: "display: inline-block;"} %>-->
-  <!--    <%= f.radio_button :review_score_search_type, :less_than %>-->
-  <!--    <%= f.label :review_score_search_type, "以下", {value: :less_than, style: "display: inline-block;"} %>-->
-  <!--  <hr>-->
-  <!--    レビュー数検索 ※0で検索すると未レビューのお店のみ表示します。-->
-  <!--    <br>-->
-  <!--    <%= f.number_field :review_count %>-->
-  <!--    <%= f.radio_button :review_count_search_type, :more_than, {:checked => true} %>-->
-  <!--    <%= f.label :review_count_search_type, "以上", {value: :more_than, style: "display: inline-block;"} %>-->
-  <!--    <%= f.radio_button :review_count_search_type, :less_than %>-->
-  <!--    <%= f.label :review_count_search_type, "以下", {value: :less_than, style: "display: inline-block;"} %>-->
-  <!--  <hr>-->
-  <!--    お気に入り数検索　※0で検索するとお気に入り数0のお店のみ表示します。-->
-  <!--    <br>-->
-  <!--    <%= f.number_field :favorite_count %>-->
-  <!--    <%= f.radio_button :favorite_count_search_type, :more_than, {:checked => true} %>-->
-  <!--    <%= f.label :favorite_count_search_type, "以上", {value: :more_than, style: "display: inline-block;"} %>-->
-  <!--    <%= f.radio_button :favorite_count_search_type, :less_than %>-->
-  <!--    <%= f.label :favorite_count_search_type, "以下", {value: :less_than, style: "display: inline-block;"} %>-->
-  <!--  <hr>-->
-  <!--    <%= f.submit :search %>-->
-  <!--  <% end %> -->
-  <!--</div>-->
+  </div>
   
   <hr>
   
   <div class="ranking_by_area">
-    (ランキングのエリア)
+    (ランキングのエリア)<br>
+    ■お気に入り数<br>
+    <% @rank_favorite_coffee_shops.each do |coffee_shop| %>
+      <%= link_to coffee_shop.name,coffee_shop_path(coffee_shop) %>：<%= coffee_shop.likers_count %>人<br>
+    <%  end %>
+    
+    <br>
+    
+    ■フォロワー数<br>
+    <% @rank_follow_users.each do |user| %>
+      <%= link_to user.name, user_path(user) %>：<%= user.followers_count %>人<br>
+    <% end %>
+    
+    <br>
+    
+    ■レビュー数<br>
+    <% @rank_review_users.each do |user| %>
+      <%= link_to user.name, user_path(user) %>：<%= Review.where(user_id: user.id).count %>件<br>
+    <% end %>
+    
   </div>
   
 </div>

--- a/db/migrate/20211114060003_add_column_likers_count.rb
+++ b/db/migrate/20211114060003_add_column_likers_count.rb
@@ -1,0 +1,5 @@
+class AddColumnLikersCount < ActiveRecord::Migration[5.2]
+  def change
+    add_column :coffee_shops, :likees_count, :integer, :default => 0
+  end
+end

--- a/db/migrate/20211114063545_add_column_likers_count2.rb
+++ b/db/migrate/20211114063545_add_column_likers_count2.rb
@@ -1,0 +1,5 @@
+class AddColumnLikersCount2 < ActiveRecord::Migration[5.2]
+  def change
+    add_column :coffee_shops, :likers_count, :integer, :default => 0
+  end
+end

--- a/db/migrate/20211114064259_add_column_follow_count.rb
+++ b/db/migrate/20211114064259_add_column_follow_count.rb
@@ -1,0 +1,5 @@
+class AddColumnFollowCount < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :followers_count, :integer, :default => 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_12_123758) do
+ActiveRecord::Schema.define(version: 2021_11_14_064259) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -57,6 +57,8 @@ ActiveRecord::Schema.define(version: 2021_11_12_123758) do
     t.string "third_image_url"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "likees_count", default: 0
+    t.integer "likers_count", default: 0
   end
 
   create_table "day_of_weeks", force: :cascade do |t|
@@ -146,6 +148,7 @@ ActiveRecord::Schema.define(version: 2021_11_12_123758) do
     t.string "instagram_url"
     t.boolean "deleted_flg", default: false, null: false
     t.string "authority"
+    t.integer "followers_count", default: 0
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
# 背景
- この機能が必要な理由
ランキングで表示することで、よりレビューやお気に入りなどを増やしてもらう

- どういう機能なのか
お気に入り数の多い店舗、フォロワーの多いユーザー、レビューの多いユーザートップ5を
トップページに表示する

- なぜこのPR単位なのか
ランキング機能でまとまるため

# やったこと
## コードベース
- 設計方針
お気にいりやフォロー機能の時に用いた[gem](https://github.com/cmer/socialization)の機能を用いてランキングを作成する
お気に入りされている数、フォローされている数を取得可能になるので、
この方法が一番手っ取り早そう

- model
店舗のカラムにお気に入りされている数を追加
ユーザーのカラムにフォローされている数を追加

- controller
トップページ表示の際に、トップ5を渡せるように変数を追加

- view
トップページにランキング部分を追加

# 画面レイアウト
- トップページ
![image](https://user-images.githubusercontent.com/87374457/141671840-4f12e945-9b4f-462f-9478-2d83cc2f3e4a.png)

# 検証内容
- [x] お気に入り数のランキングは表示されるか
- [x] フォロー数のランキングは表示されるか
- [x] レビュー数のランキングは表示されるか