### PR TITLE
bestshopを登録機能の追加

### DIFF
--- a/app/assets/stylesheets/web.scss
+++ b/app/assets/stylesheets/web.scss
@@ -104,3 +104,10 @@
     top: 22px;
   }
 }
+
+.best_shop {
+  text-align: center;
+  float: right;
+  border: solid;
+  border-color: darkgray;
+}

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -64,6 +64,13 @@ class UsersController < ApplicationController
     @follower = @user.followers(User)
   end
   
+  def setbestshop
+    @coffee_shop = CoffeeShop.find_by(id: params[:id])
+    set_best_shop
+    @user.update(best_shop_id: @set_best_shop_id)
+    redirect_to coffee_shop_path(@coffee_shop.id)
+  end
+  
   private
   def set_user
     @user = current_user
@@ -75,5 +82,14 @@ class UsersController < ApplicationController
   
   def password_set?
     user_params[:password].present? && user_params[:password_confirmation].present? ? true : false
+  end
+  
+  def set_best_shop
+    # 同じなら解除
+    if @user.best_shop_id == @coffee_shop.id
+      @set_best_shop_id = ""
+    else
+      @set_best_shop_id = @coffee_shop.id
+    end
   end
 end

--- a/app/controllers/web_controller.rb
+++ b/app/controllers/web_controller.rb
@@ -3,6 +3,7 @@ class WebController < ApplicationController
     @rank_favorite_coffee_shops = CoffeeShop.find(CoffeeShop.all.order('likers_count desc').limit(5).pluck(:id))
     @rank_follow_users = User.find(User.all.order('followers_count desc').limit(5).pluck(:id))
     @rank_review_users = User.find(Review.group(:user_id).order('count(user_id)desc').limit(5).pluck(:user_id))
+    @my_best_shop = CoffeeShop.find(current_user.best_shop_id) if current_user.best_shop_id.present?
   end
   
   def search

--- a/app/views/coffee_shops/show.html.erb
+++ b/app/views/coffee_shops/show.html.erb
@@ -5,6 +5,9 @@
 		<i class="fa fa-heart"></i><%= current_user.likes?(@coffee_shop) ? "お気に入り解除" : "お気に入り" %>
 	<% end %>
 	<br>
+	<%= link_to setbestshop_user_path, class: "btn favorite-button text-favorite" do %>
+		<i class="fa fa-heart"></i><%= current_user.best_shop_id == @coffee_shop.id ? "mybest解除" : "mybest" %>
+	<% end %>
 	お気に入り数：<%= @coffee_shop.likers_count %>
 	<br>
 	お気に入りユーザー：
@@ -74,4 +77,3 @@
 	<% end %>
 	
 <%= link_to "戻る", :back %>
-

--- a/app/views/web/index.html.erb
+++ b/app/views/web/index.html.erb
@@ -3,6 +3,15 @@
     <!-- user_signed_in? はユーザがログインしているか調べるdeviseのHelperメソッド -->
     <!--サインインしている-->
     <% if user_signed_in? %>
+      <% if @my_best_shop.present? %>
+        <%= link_to(coffee_shop_path(@my_best_shop.id)) do %>
+          <div class="best_shop">
+            my best shop<br>
+            <%= @my_best_shop.name %><br>
+            <%= render partial: 'shared/show_image_first', locals: { target: @my_best_shop, image_size: "100x100" } %>
+          </div>
+        <% end %>
+      <% end %>
       <%= link_to(favorite_users_path) do %>
         <span class="badge badge-warning">Favorite shops</span>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,6 +51,7 @@ Rails.application.routes.draw do
     end
     member do 
       get :follow
+      get :setbestshop
     end
   end
   

--- a/db/migrate/20211121064428_add_my_best_shop_to_users.rb
+++ b/db/migrate/20211121064428_add_my_best_shop_to_users.rb
@@ -1,0 +1,5 @@
+class AddMyBestShopToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :best_shop_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_20_042049) do
+ActiveRecord::Schema.define(version: 2021_11_21_064428) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -171,6 +171,7 @@ ActiveRecord::Schema.define(version: 2021_11_20_042049) do
     t.boolean "deleted_flg", default: false, null: false
     t.string "authority"
     t.integer "followers_count", default: 0
+    t.integer "best_shop_id"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
# 背景
- この機能が必要な理由
お気に入りとは別のおすすめ機能をつけることで、
よりおすすめをすることができる
本当に一番おすすめしたいお店を表示することができる

- どういう機能なのか
ユーザーが1店舗だけ、my best shopとして登録できる

- なぜこのPR単位なのか
my best shopでまとめるため

# やったこと
## コードベース
- 設計方針
Userのカラムにmy best shopのidを追加
登録は店舗詳細画面からできるようにする

- model
Userのカラムにbest_shop_idを追加

- controller
Userコントローラーにby best shopを切り替える機能を追加

- view
店舗詳細画面に切り替えるためのボタンを設置

# 画面レイアウト
- 店舗詳細画面
![image](https://user-images.githubusercontent.com/87374457/142754681-b6a46edf-a0e7-4fff-9313-5db1c5302986.png)

# 検証内容
- [x] my best shopの登録はできるか
- [x] my best shopの変更はできるか
- [x] my best shopの解除はできるか