### PR TITLE
コーヒー豆検索機能の追加

### DIFF
--- a/app/controllers/coffee_shops_controller.rb
+++ b/app/controllers/coffee_shops_controller.rb
@@ -49,6 +49,7 @@ class CoffeeShopsController < ApplicationController
       hash[:slack_time] = params[:slack_time]
       hash[:age_group] = params[:age_group]
       hash[:shop_atmosphere_ids] = params[:shop_atmosphere_ids]
+      hash[:coffee_bean_ids] = params[:coffee_bean_ids]
       hash
     end
     
@@ -58,23 +59,23 @@ class CoffeeShopsController < ApplicationController
       @coffee_shop_search_conditions << "電話番号：#{params[:tel]}" if params[:tell].present?
       if params[:search_category_ids].present?
         search_categorys = SearchCategory.where(id: params[:search_category_ids])
-        return_message = "こだわり検索："
+        return_message = "こだわり："
         search_categorys.each do |search_category|
           return_message << "#{search_category.name} "
         end
         @coffee_shop_search_conditions << return_message
       end
       if params[:review_score].present?
-        @coffee_shop_search_conditions << "レビュー点数検索：#{params[:review_score]}点以上" if params[:review_score_search_type].eql?("more_than")
-        @coffee_shop_search_conditions << "レビュー点数検索：#{params[:review_score]}点以下" if params[:review_score_search_type].eql?("less_than")
+        @coffee_shop_search_conditions << "レビュー点数：#{params[:review_score]}点以上" if params[:review_score_search_type].eql?("more_than")
+        @coffee_shop_search_conditions << "レビュー点数：#{params[:review_score]}点以下" if params[:review_score_search_type].eql?("less_than")
       end
       if params[:review_count].present?
-        @coffee_shop_search_conditions << "レビュー数検索：#{params[:review_count]}件以上" if params[:review_count_search_type].eql?("more_than")
-        @coffee_shop_search_conditions << "レビュー数検索：#{params[:review_count]}件以下" if params[:review_count_search_type].eql?("less_than")
+        @coffee_shop_search_conditions << "レビュー数：#{params[:review_count]}件以上" if params[:review_count_search_type].eql?("more_than")
+        @coffee_shop_search_conditions << "レビュー数：#{params[:review_count]}件以下" if params[:review_count_search_type].eql?("less_than")
       end
       if params[:favorite_count].present?
-        @coffee_shop_search_conditions << "お気に入り数検索：#{params[:favorite_count]}件以上" if params[:favorite_count_search_type].eql?("more_than")
-        @coffee_shop_search_conditions << "お気に入り数検索：#{params[:favorite_count]}件以下" if params[:favorite_count_search_type].eql?("less_than")
+        @coffee_shop_search_conditions << "お気に入り数：#{params[:favorite_count]}件以上" if params[:favorite_count_search_type].eql?("more_than")
+        @coffee_shop_search_conditions << "お気に入り数：#{params[:favorite_count]}件以下" if params[:favorite_count_search_type].eql?("less_than")
       end
       @coffee_shop_search_conditions << "エリア：#{Municipality.find(params[:municipality_id]).name}" if params[:municipality_id].present?
       @coffee_shop_search_conditions << "営業時間：#{params[:business_hour]}" if params[:business_hour].present?
@@ -85,6 +86,14 @@ class CoffeeShopsController < ApplicationController
         return_message = "お店の雰囲気："
         shop_atmospheres.each do |shop_atmospere|
           return_message << "#{shop_atmospere.name}"
+        end
+        @coffee_shop_search_conditions << return_message
+      end
+      if params[:coffee_bean_ids].present?
+        coffee_beans = CoffeeBean.where(id: params[:coffee_bean_ids])
+        return_message = "コーヒー豆："
+        coffee_beans.each do |coffee_bean|
+          return_message << "#{coffee_bean.name}"
         end
         @coffee_shop_search_conditions << return_message
       end

--- a/app/controllers/dashboard/coffee_beans_controller.rb
+++ b/app/controllers/dashboard/coffee_beans_controller.rb
@@ -1,0 +1,59 @@
+class Dashboard::CoffeeBeansController < ApplicationController
+  before_action :set_coffee_bean, only: %w[show edit update destroy]
+  before_action :check_user_authority, except: :index
+  layout "dashboard/dashboard"
+  
+  def index
+    @coffee_beans = CoffeeBean.all
+    @coffee_bean = CoffeeBean.new
+  end
+  
+  def show
+  end
+  
+  def create
+    @coffee_bean = CoffeeBean.new(coffee_bean_params)
+    if @coffee_bean.save
+      redirect_to dashboard_coffee_beans_path, notice: '登録完了'
+    else
+      flash[:alert] = @coffee_bean.errors.full_messages
+      redirect_back(fallback_location: dashboard_coffee_beans_path)
+    end
+  end
+  
+  def edit
+  end
+  
+  def update
+    if @coffee_bean.update(coffee_bean_params)
+      redirect_to dashboard_coffee_beans_path, notice: '変更完了'
+    else
+      flash[:alert] = @coffee_bean.errors.full_messages
+      redirect_back(fallback_location: dashboard_coffee_beans_path)
+    end
+  end
+  
+  def destroy
+    @coffee_bean.destroy
+    redirect_to dashboard_coffee_beans_path
+  end
+  
+  private
+  
+  def set_coffee_bean
+    @coffee_bean = CoffeeBean.find(params[:id])
+  end
+  
+  def coffee_bean_params
+    params.require(:coffee_bean).permit(:name)
+  end
+  
+  def check_user_authority
+    @user = current_user
+    if @user.authority.eql?("2")
+      flash[:alert] = "権限がありません"
+      redirect_to dashboard_path
+    end
+  end
+  
+end

--- a/app/controllers/dashboard/coffee_shops_controller.rb
+++ b/app/controllers/dashboard/coffee_shops_controller.rb
@@ -69,7 +69,7 @@ class Dashboard::CoffeeShopsController < ApplicationController
   end
   
   def coffee_shop_params
-    params.require(:coffee_shop).permit(:name, :shop_url, :address, :tell, :access, :business_start_hour, :business_end_hour, :instagram_url, :instagram_spot_url, :municipalitie_id, :slack_time_start, :slack_time_end, :age_group, :first_image_url, { :search_category_ids => [], :shop_atmosphere_ids => [] }, images: [])
+    params.require(:coffee_shop).permit(:name, :shop_url, :address, :tell, :access, :business_start_hour, :business_end_hour, :instagram_url, :instagram_spot_url, :municipalitie_id, :slack_time_start, :slack_time_end, :age_group, :first_image_url, { :search_category_ids => [], :shop_atmosphere_ids => [], :coffee_bean_ids => [] }, images: [])
   end
   
   def check_user_authority

--- a/app/models/coffee_bean.rb
+++ b/app/models/coffee_bean.rb
@@ -1,0 +1,13 @@
+class CoffeeBean < ApplicationRecord
+  has_many :coffee_shop_coffee_beans, dependent: :destroy
+  has_many :coffee_shops, :through => :coffee_shop_coffee_beans
+  
+  #空白禁止
+  validates :name, presence: true
+  
+  # 重複禁止
+	validates :name, uniqueness: true
+	
+	# 文字数
+	validates :name, length: { maximum: 15}
+end

--- a/app/models/coffee_shop.rb
+++ b/app/models/coffee_shop.rb
@@ -4,6 +4,8 @@ class CoffeeShop < ApplicationRecord
 	has_many :reviews, dependent: :destroy
 	has_many :coffee_shop_shop_atmospheres, dependent: :destroy
 	has_many :shop_atmospheres, :through => :coffee_shop_shop_atmospheres
+	has_many :coffee_shop_coffee_beans, dependent: :destroy
+	has_many :coffee_beans, :through => :coffee_shop_coffee_beans
 	
 	accepts_nested_attributes_for :coffee_shop_search_categories, allow_destroy: true
 	accepts_nested_attributes_for :coffee_shop_shop_atmospheres, allow_destroy: true

--- a/app/models/coffee_shop_coffee_bean.rb
+++ b/app/models/coffee_shop_coffee_bean.rb
@@ -1,0 +1,4 @@
+class CoffeeShopCoffeeBean < ApplicationRecord
+  belongs_to :coffee_shop
+  belongs_to :coffee_bean
+end

--- a/app/service/coffee_shop_search_service.rb
+++ b/app/service/coffee_shop_search_service.rb
@@ -52,6 +52,9 @@ class CoffeeShopSearchService
     # 雰囲気検索
     search_by_shop_atmosphere if @shop_atmosphere_ids.present?
     
+    # コーヒー豆
+    search_by_coffee_bean if @coffee_bean_ids.present?
+    
     @coffee_shops
   end
   
@@ -184,6 +187,12 @@ class CoffeeShopSearchService
   # 雰囲気検索
   def search_by_shop_atmosphere
     coffee_shop_ids = CoffeeShopShopAtmosphere.where(shop_atmosphere_id: @shop_atmosphere_ids).pluck(:coffee_shop_id)
+    @coffee_shops = @coffee_shops.where(id: coffee_shop_ids)
+  end
+  
+  # コーヒー豆検索
+  def search_by_coffee_bean
+    coffee_shop_ids = CoffeeShopCoffeeBean.where(coffee_bean_id: @coffee_bean_ids).pluck(:coffee_shop_id)
     @coffee_shops = @coffee_shops.where(id: coffee_shop_ids)
   end
   

--- a/app/views/dashboard/coffee_beans/edit.html.erb
+++ b/app/views/dashboard/coffee_beans/edit.html.erb
@@ -1,0 +1,9 @@
+<h1>豆名編集</h1>
+
+<%= form_with model: @coffee_bean, url: dashboard_coffee_bean_path(@coffee_bean), local: true do |f| %>
+  <%= f.label :name, "豆名" %>
+  <%= f.text_field :name %>
+  
+  <%= f.submit "更新" %>
+<% end %>
+<%= link_to "雰囲気一覧に戻る", dashboard_coffee_beans_path %>

--- a/app/views/dashboard/coffee_beans/index.html.erb
+++ b/app/views/dashboard/coffee_beans/index.html.erb
@@ -1,0 +1,37 @@
+<div class="w-75">
+  
+  <h1>コーヒー豆一覧</h1>
+  
+  <%= form_with(model: @coffee_bean, url: dashboard_coffee_beans_path, local: true) do |f| %>
+    <%= f.label :name, "豆名" %>
+    <%= f.text_field :name %>
+    
+    <%= f.submit "新規作成" %>
+  <% end %>
+  
+  <table class="table mt-5">
+    <thead>
+      <tr>
+        <th scope="col" class="w-25">ID</th>
+        <th scope="col">豆名</th>
+        <th scope="col"></th>
+        <th scope="col"></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @coffee_beans.each do |coffee_bean| %>
+      <tr>
+        <td scope="row"><%= coffee_bean.id %></td>
+        <td><%= coffee_bean.name %></td>
+        <td>
+          <%= link_to "編集", edit_dashboard_coffee_bean_path(coffee_bean) %>
+          
+        </td>
+        <td>
+          <%= link_to "削除", dashboard_coffee_bean_path(coffee_bean), method: :delete, data: { confirm: 'Are you sure?' } %>
+        </td>
+      </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/dashboard/coffee_shops/edit.html.erb
+++ b/app/views/dashboard/coffee_shops/edit.html.erb
@@ -41,14 +41,20 @@
   <br>
   検索カテゴリ<br>
   <div class="check_box">
-    <%= f.collection_check_boxes(:search_category_ids, SearchCategory.all, :id, :name) do |b| %>
-      <%= b.label { b.check_box + b.text } %>
+    <%= f.collection_check_boxes(:search_category_ids, SearchCategory.all, :id, :name) do |search_category| %>
+      <%= search_category.label { search_category.check_box + search_category.text } %>
     <% end %>
   </div>
   お店の雰囲気<br>
   <div class="check_box">
-    <%= f.collection_check_boxes(:shop_atmosphere_ids, ShopAtmosphere.all, :id, :name) do |b| %>
-      <%= b.label { b.check_box + b.text } %>
+    <%= f.collection_check_boxes(:shop_atmosphere_ids, ShopAtmosphere.all, :id, :name) do |shop_atmosphere| %>
+      <%= shop_atmosphere.label { shop_atmosphere.check_box + shop_atmosphere.text } %>
+    <% end %>
+  </div>
+  コーヒー豆<br>
+  <div class="check_box">
+    <%= f.collection_check_boxes(:coffee_bean_ids, CoffeeBean.all, :id, :name) do |coffee_bean| %>
+      <%= coffee_bean.label { coffee_bean.check_box + coffee_bean.text } %>
     <% end %>
   </div>
   <%= f.submit "更新" %>

--- a/app/views/dashboard/coffee_shops/new.html.erb
+++ b/app/views/dashboard/coffee_shops/new.html.erb
@@ -53,6 +53,13 @@
     <% end %>
   </div>
   
+  コーヒー豆<br>
+  <div class="check_box">
+    <%= f.collection_check_boxes(:coffee_bean_ids, CoffeeBean.all, :id, :name) do |d| %>
+      <%= d.label { d.check_box + d.text } %>
+    <% end %>
+  </div>
+  
   <%= f.submit "追加" %>
 <% end %>
 

--- a/app/views/layouts/dashboard/_sidebar.html.erb
+++ b/app/views/layouts/dashboard/_sidebar.html.erb
@@ -16,4 +16,6 @@
     <%= link_to "カテゴリ一覧", dashboard_search_categories_path %>
   <br>
     <%= link_to "お店の雰囲気一覧", dashboard_shop_atmospheres_path %>
+  <br>
+    <%= link_to "コーヒー豆一覧", dashboard_coffee_beans_path %>
 </div>

--- a/app/views/web/search.html.erb
+++ b/app/views/web/search.html.erb
@@ -91,6 +91,16 @@
       <%= f.select :age_group, AgeGroup.pluck(:name), { include_blank: 'select' }, :class => 'search-select' %>
     </div>
     
+    <div class="search-container">
+      <div class="search-name">コーヒー豆</div>
+      <%= f.collection_check_boxes(:coffee_bean_ids, CoffeeBean.all, :id, :name, {include_hidden: false}) do |coffee_bean| %>
+        <div class="search-checkbox">
+          <%= coffee_bean.check_box %>
+          <%= coffee_bean.label %>
+        </div>
+      <% end %>
+    </div>
+    
     <hr>
     <%= f.submit :search %>
   <% end %> 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
     resources :prefectures, except: [:new]
     resources :municipalities, except: [:new]
     resources :shop_atmospheres, except: [:new]
+    resources :coffee_beans, except: [:new]
   end
   
   devise_for :users, :controllers => {

--- a/db/migrate/20211123103736_create_coffee_beans.rb
+++ b/db/migrate/20211123103736_create_coffee_beans.rb
@@ -1,0 +1,9 @@
+class CreateCoffeeBeans < ActiveRecord::Migration[5.2]
+  def change
+    create_table :coffee_beans do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20211123103921_create_coffee_shop_coffee_beans.rb
+++ b/db/migrate/20211123103921_create_coffee_shop_coffee_beans.rb
@@ -1,0 +1,10 @@
+class CreateCoffeeShopCoffeeBeans < ActiveRecord::Migration[5.2]
+  def change
+    create_table :coffee_shop_coffee_beans do |t|
+      t.integer :coffee_shop_id
+      t.integer :coffee_bean_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_21_064428) do
+ActiveRecord::Schema.define(version: 2021_11_23_103921) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -35,6 +35,19 @@ ActiveRecord::Schema.define(version: 2021_11_21_064428) do
 
   create_table "age_groups", force: :cascade do |t|
     t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "coffee_beans", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "coffee_shop_coffee_beans", force: :cascade do |t|
+    t.integer "coffee_shop_id"
+    t.integer "coffee_bean_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/test/fixtures/coffee_beans.yml
+++ b/test/fixtures/coffee_beans.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+
+two:
+  name: MyString

--- a/test/fixtures/coffee_shop_coffee_beans.yml
+++ b/test/fixtures/coffee_shop_coffee_beans.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  coffee_shop_id: 1
+  coffee_bean_id: 1
+
+two:
+  coffee_shop_id: 1
+  coffee_bean_id: 1

--- a/test/models/coffee_bean_test.rb
+++ b/test/models/coffee_bean_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class CoffeeBeanTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/coffee_shop_coffee_bean_test.rb
+++ b/test/models/coffee_shop_coffee_bean_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class CoffeeShopCoffeeBeanTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# 背景
- この機能が必要な理由
取り扱っているコーヒー豆でも検索できるようにするため

- どういう機能なのか
店舗情報にコーヒー豆を追加し、コーヒー豆から店舗の検索ができる

- なぜこのPR単位なのか
コーヒー豆の登録から検索までまとめるため

# やったこと
## コードベース
- 設計方針
コーヒー豆と店舗は多対多の関係で作成するため、
中間テーブルを用いて実装する
コーヒー豆は登録時も検索時も複数選択できる
検索条件に複数登録した場合はORで検索を行う

- model
コーヒー豆と中間テーブルを作成

- controller
コーヒー豆のコントローラーを作成

- view
管理画面にコーヒー豆を管理するための画面を作成

# 画面レイアウト
- コーヒー豆一覧
![image](https://user-images.githubusercontent.com/87374457/143229279-0a744a5f-c1df-4d04-9ff5-a805bbb44f9b.png)

- 検索画面
![image](https://user-images.githubusercontent.com/87374457/143229349-90508649-4c4d-43ee-bad2-cbd259bbb370.png)

# 検証内容
- [x] コーヒー豆の登録ができるか
- [x] コーヒー豆の編集ができるか
- [x] コーヒー豆の削除ができるか
- [x] 店舗情報にコーヒー豆を登録できるか
- [x] 店舗情報のコーヒー豆を編集できるか
- [x] コーヒー豆から店舗の検索ができるか
- [x]  ボタンが押せるか