### PR TITLE
お店の静かさ検索機能の作成

### DIFF
--- a/app/assets/javascripts/dashboard/coffee_shops/new.js
+++ b/app/assets/javascripts/dashboard/coffee_shops/new.js
@@ -1,39 +1,48 @@
-document.addEventListener('DOMContentLoaded', () => {
+function handleImage(image) {
+    let reader = new FileReader();
+    reader.onload = function() {
+      let imagePreview = document.getElementById("image-preview");
+      imagePreview.src = reader.result;
+      imagePreview.className += "img-fluid w-25";
+    };
+  reader.readAsDataURL(image[0]);
+}
+// document.addEventListener('DOMContentLoaded', () => {
   
-  const ImageList = document.getElementById('new-image');
+//   const ImageList = document.getElementById('new-image');
   
-  const createImageHTML = (blob) => {  
-    const imageElement = document.createElement('div');
-    imageElement.setAttribute('class', "image-element");
-    let imageElementNum = document.querySelectorAll('.image-element').length;
+//   const createImageHTML = (blob) => {  
+//     const imageElement = document.createElement('div');
+//     imageElement.setAttribute('class', "image-element");
+//     let imageElementNum = document.querySelectorAll('.image-element').length;
     
-    const blobImage = document.createElement('img'); 
-    blobImage.setAttribute('class', 'new-img'); 
-    blobImage.setAttribute('src', blob); 
+//     const blobImage = document.createElement('img'); 
+//     blobImage.setAttribute('class', 'new-img'); 
+//     blobImage.setAttribute('src', blob); 
     
-    const inputHTML = document.createElement('input');
-    inputHTML.setAttribute('id', `coffee_shop_images_${imageElementNum}`);
-    inputHTML.setAttribute('class', 'coffee_shop_images');
-    inputHTML.setAttribute('name', 'coffee_shop[images][]');
-    inputHTML.setAttribute('type', 'file');
+//     const inputHTML = document.createElement('input');
+//     inputHTML.setAttribute('id', `coffee_shop_images_${imageElementNum}`);
+//     inputHTML.setAttribute('class', 'coffee_shop_images');
+//     inputHTML.setAttribute('name', 'coffee_shop[images][]');
+//     inputHTML.setAttribute('type', 'file');
     
-    imageElement.appendChild(blobImage);
-    if (imageElementNum < 2) {
-      imageElement.appendChild(inputHTML);
-    }
-    ImageList.appendChild(imageElement);
+//     imageElement.appendChild(blobImage);
+//     if (imageElementNum < 2) {
+//       imageElement.appendChild(inputHTML);
+//     }
+//     ImageList.appendChild(imageElement);
     
-    inputHTML.addEventListener('change', (e) => {
-      const file = e.target.files[0];
-      const blob = window.URL.createObjectURL(file);
-      createImageHTML(blob);
-    });
-  }; 
+//     inputHTML.addEventListener('change', (e) => {
+//       const file = e.target.files[0];
+//       const blob = window.URL.createObjectURL(file);
+//       createImageHTML(blob);
+//     });
+//   }; 
   
-  document.getElementById('coffee_shop_images').addEventListener('change', (e) =>{
+//   document.getElementById('coffee_shop_images').addEventListener('change', (e) =>{
     
-    const file = e.target.files[0];
-    const blob = window.URL.createObjectURL(file); 
-    createImageHTML(blob);
-  });
-});
+//     const file = e.target.files[0];
+//     const blob = window.URL.createObjectURL(file); 
+//     createImageHTML(blob);
+//   });
+// });

--- a/app/controllers/coffee_shops_controller.rb
+++ b/app/controllers/coffee_shops_controller.rb
@@ -52,6 +52,7 @@ class CoffeeShopsController < ApplicationController
       hash[:coffee_bean_ids] = params[:coffee_bean_ids]
       hash[:shop_seats] = params[:shop_seats]
       hash[:shop_seats_search_type] = params[:shop_seats_search_type]
+      hash[:volume_in_shop_ids] = params[:volume_in_shop_ids]
       hash
     end
     
@@ -62,8 +63,12 @@ class CoffeeShopsController < ApplicationController
       if params[:search_category_ids].present?
         search_categorys = SearchCategory.where(id: params[:search_category_ids])
         return_message = "こだわり："
-        search_categorys.each do |search_category|
-          return_message << "#{search_category.name} "
+        search_categorys.each_with_index do |search_category, i|
+          if i.eql?(0)
+            return_message << "#{search_category.name}"
+          else
+            return_message << "or#{search_category.name}"
+          end
         end
         @coffee_shop_search_conditions << return_message
       end
@@ -86,22 +91,42 @@ class CoffeeShopsController < ApplicationController
       if params[:shop_atmosphere_ids].present?
         shop_atmospheres = ShopAtmosphere.where(id: params[:shop_atmosphere_ids])
         return_message = "お店の雰囲気："
-        shop_atmospheres.each do |shop_atmospere|
-          return_message << "#{shop_atmospere.name}"
+        shop_atmospheres.each_with_index do |shop_atmospere, i|
+          if i.eql?(0)
+            return_message << "#{shop_atmospere.name}"
+          else
+            return_message << "or#{shop_atmospere.name}"
+          end
         end
         @coffee_shop_search_conditions << return_message
       end
       if params[:coffee_bean_ids].present?
         coffee_beans = CoffeeBean.where(id: params[:coffee_bean_ids])
         return_message = "コーヒー豆："
-        coffee_beans.each do |coffee_bean|
-          return_message << "#{coffee_bean.name}"
+        coffee_beans.each_with_index do |coffee_bean, i|
+          if i.eql?(0)
+            return_message << "#{coffee_bean.name}"
+          else
+            return_message << "or#{coffee_bean.name}"
+          end
         end
         @coffee_shop_search_conditions << return_message
       end
       if params[:shop_seats].present?
         @coffee_shop_search_conditions << "席数：#{params[:shop_seats]}席以上" if params[:shop_seats_search_type].eql?("more_than") 
         @coffee_shop_search_conditions << "席数：#{params[:shop_seats]}席以下" if params[:shop_seats_search_type].eql?("less_than")
+      end
+      if params[:volume_in_shop_ids].present?
+        volume_in_shops = VolumeInShop.where(id: params[:volume_in_shop_ids])
+        return_message = "静かさ："
+        volume_in_shops.each_with_index do |volume_in_shop, i|
+          if i.eql?(0)
+            return_message << "#{volume_in_shop.name}"
+          else
+            return_message << "or#{volume_in_shop.name}"
+          end
+        end
+        @coffee_shop_search_conditions << return_message
       end
     end
 end

--- a/app/controllers/dashboard/coffee_shops_controller.rb
+++ b/app/controllers/dashboard/coffee_shops_controller.rb
@@ -68,7 +68,7 @@ class Dashboard::CoffeeShopsController < ApplicationController
   end
   
   def coffee_shop_params
-    params.require(:coffee_shop).permit(:name, :shop_url, :address, :tell, :access, :business_start_hour, :business_end_hour, :instagram_url, :instagram_spot_url, :municipalitie_id, :slack_time_start, :slack_time_end, :age_group, :shop_seats, { :search_category_ids => [], :shop_atmosphere_ids => [], :coffee_bean_ids => [] }, images: [])
+    params.require(:coffee_shop).permit(:name, :shop_url, :address, :tell, :access, :business_start_hour, :business_end_hour, :instagram_url, :instagram_spot_url, :municipalitie_id, :slack_time_start, :slack_time_end, :age_group, :shop_seats, { :search_category_ids => [], :shop_atmosphere_ids => [], :coffee_bean_ids => [], :volume_in_shop_ids => [] }, images: [])
   end
   
   def check_user_authority

--- a/app/controllers/dashboard/volume_in_shops_controller.rb
+++ b/app/controllers/dashboard/volume_in_shops_controller.rb
@@ -1,0 +1,58 @@
+class Dashboard::VolumeInShopsController < ApplicationController
+  before_action :set_volume_in_shop, only: %w[show edit update destroy]
+  before_action :check_user_authority, except: :index
+  layout "dashboard/dashboard"
+  
+  def index
+    @volume_in_shops = VolumeInShop.all
+    @volume_in_shop = VolumeInShop.new
+  end
+  
+  def show
+  end
+  
+  def create
+    @volume_in_shop = VolumeInShop.new(volume_in_shop_params)
+    if @volume_in_shop.save
+      redirect_to dashboard_volume_in_shops_path, notice: '登録完了'
+    else
+      flash[:alert] = @volume_in_shop.errors.full_messages
+      redirect_back(fallback_location: dashboard_volume_in_shops_path)
+    end
+  end
+  
+  def edit
+  end
+  
+  def update
+    if @volume_in_shop.update(volume_in_shop_params)
+      redirect_to dashboard_volume_in_shops_path, notice: '変更完了'
+    else
+      flash[:alert] = @volume_in_shop.errors.full_messages
+      redirect_back(fallback_location: dashboard_volume_in_shops_path)
+    end
+  end
+  
+  def destroy
+    @volume_in_shop.destroy
+    redirect_to dashboard_volume_in_shops_path
+  end
+  
+  private
+  
+  def set_volume_in_shop
+    @volume_in_shop = VolumeInShop.find(params[:id])
+  end
+  
+  def volume_in_shop_params
+    params.require(:volume_in_shop).permit(:name)
+  end
+  
+  def check_user_authority
+    @user = current_user
+    if @user.authority.eql?("2")
+      flash[:alert] = "権限がありません"
+      redirect_to dashboard_path
+    end
+  end
+end

--- a/app/models/coffee_shop.rb
+++ b/app/models/coffee_shop.rb
@@ -1,14 +1,22 @@
 class CoffeeShop < ApplicationRecord
 	has_many :coffee_shop_search_categories, dependent: :destroy
+	
 	has_many :search_categories, :through => :coffee_shop_search_categories
 	has_many :reviews, dependent: :destroy
+	
 	has_many :coffee_shop_shop_atmospheres, dependent: :destroy
 	has_many :shop_atmospheres, :through => :coffee_shop_shop_atmospheres
+	
 	has_many :coffee_shop_coffee_beans, dependent: :destroy
 	has_many :coffee_beans, :through => :coffee_shop_coffee_beans
 	
+	has_many :coffee_shop_volume_in_shops, dependent: :destroy
+	has_many :volume_in_shops, :through => :coffee_shop_volume_in_shops
+	
 	accepts_nested_attributes_for :coffee_shop_search_categories, allow_destroy: true
 	accepts_nested_attributes_for :coffee_shop_shop_atmospheres, allow_destroy: true
+	accepts_nested_attributes_for :coffee_shop_coffee_beans, allow_destroy: true
+	accepts_nested_attributes_for :coffee_shop_volume_in_shops, allow_destroy: true
 	acts_as_likeable
 	has_many_attached :images
 	

--- a/app/models/coffee_shop_volume_in_shop.rb
+++ b/app/models/coffee_shop_volume_in_shop.rb
@@ -1,0 +1,4 @@
+class CoffeeShopVolumeInShop < ApplicationRecord
+  belongs_to :coffee_shop
+  belongs_to :volume_in_shop
+end

--- a/app/models/volume_in_shop.rb
+++ b/app/models/volume_in_shop.rb
@@ -1,0 +1,13 @@
+class VolumeInShop < ApplicationRecord
+  has_many :coffee_shop_volume_in_shops, dependent: :destroy
+  has_many :coffee_shops, :through => :coffee_shop_volume_in_shops
+  
+  #空白禁止
+  validates :name, presence: true
+  
+  # 重複禁止
+	validates :name, uniqueness: true
+	
+	# 文字数
+	validates :name, length: { maximum: 15}
+end

--- a/app/service/coffee_shop_search_service.rb
+++ b/app/service/coffee_shop_search_service.rb
@@ -16,6 +16,7 @@ class CoffeeShopSearchService
     @shop_atmosphere_ids = hash[:shop_atmosphere_ids]
     @shop_seats = hash[:shop_seats]
     @shop_seats_search_type = hash[:shop_seats_search_type]
+    @volume_in_shop_ids = hash[:volume_in_shop_ids]
   end
   
   def search
@@ -59,6 +60,9 @@ class CoffeeShopSearchService
     
     # 席数
     search_by_shop_seats if @shop_seats.present?
+    
+    # しずかさ
+    search_by_volume_in_shop if @volume_in_shop_ids.present?
     
     @coffee_shops
   end
@@ -213,6 +217,12 @@ class CoffeeShopSearchService
       end
       @coffee_shops = @coffee_shops.where(id: coffee_shop_ids)
     end
+  end
+  
+  # 静かさ検索
+  def search_by_volume_in_shop
+    coffee_shop_ids = CoffeeShopVolumeInShop.where(volume_in_shop_id: @volume_in_shop_ids).pluck(:coffee_shop_id)
+    @coffee_shops = @coffee_shops.where(id: coffee_shop_ids)
   end
   
 end

--- a/app/views/dashboard/coffee_beans/edit.html.erb
+++ b/app/views/dashboard/coffee_beans/edit.html.erb
@@ -6,4 +6,4 @@
   
   <%= f.submit "更新" %>
 <% end %>
-<%= link_to "雰囲気一覧に戻る", dashboard_coffee_beans_path %>
+<%= link_to "豆一覧に戻る", dashboard_coffee_beans_path %>

--- a/app/views/dashboard/coffee_shops/edit.html.erb
+++ b/app/views/dashboard/coffee_shops/edit.html.erb
@@ -59,6 +59,13 @@
   </div>
   席数<%= f.number_field :shop_seats %>
   <br>
+  静かさ<br>
+  <div class="check_box">
+    <%= f.collection_check_boxes(:volume_in_shop_ids, VolumeInShop.all, :id, :name) do |volume_in_shop| %>
+      <%= volume_in_shop.label { volume_in_shop.check_box + volume_in_shop.text } %>
+    <% end %>  
+  </div>
+  <br>
   <%= f.submit "更新" %>
 <% end %>
 

--- a/app/views/dashboard/coffee_shops/new.html.erb
+++ b/app/views/dashboard/coffee_shops/new.html.erb
@@ -33,8 +33,8 @@
     <%= f.label "画像" %>
     <div class="d-flex flex-column ml-2">
       <small class="mb-3">600px×600px推奨。<br>画像をアップロードして下さい。</small>
-      <%= f.label "画像を選択" %>
-      <%= f.file_field :images, multiple: true %>
+      <%= f.file_field :images, onChange: "javascript: handleImage(this.files);", multiple: true %>
+      <img id="image-preview",size="50x50">
     </div>
     <div id="new-image"></div>
   </div>
@@ -63,6 +63,13 @@
   席数<%= f.number_field :shop_seats %>
   
   <br>
+  
+  静かさ<br>
+  <div class="check_box">
+    <%= f.collection_check_boxes(:volume_in_shop_ids, VolumeInShop.all, :id, :name) do |volume_in_shop| %>
+      <%= volume_in_shop.label { volume_in_shop.check_box + volume_in_shop.text } %>
+    <% end %>  
+  </div>
   <%= f.submit "追加" %>
 <% end %>
 

--- a/app/views/dashboard/volume_in_shops/edit.html.erb
+++ b/app/views/dashboard/volume_in_shops/edit.html.erb
@@ -1,0 +1,9 @@
+<h1>静かさ編集</h1>
+
+<%= form_with model: @volume_in_shop, url: dashboard_volume_in_shop_path(@volume_in_shop), local: true do |f| %>
+  <%= f.label :name, "静かさ" %>
+  <%= f.text_field :name %>
+  
+  <%= f.submit "更新" %>
+<% end %>
+<%= link_to "静かさ一覧に戻る", dashboard_volume_in_shops_path %>

--- a/app/views/dashboard/volume_in_shops/index.html.erb
+++ b/app/views/dashboard/volume_in_shops/index.html.erb
@@ -1,0 +1,37 @@
+<div class="w-75">
+  
+  <h1>静かさ一覧</h1>
+  
+  <%= form_with(model: @volume_in_shop, url: dashboard_volume_in_shops_path, local: true) do |f| %>
+    <%= f.label :name, "静かさ" %>
+    <%= f.text_field :name %>
+    
+    <%= f.submit "新規作成" %>
+  <% end %>
+  
+  <table class="table mt-5">
+    <thead>
+      <tr>
+        <th scope="col" class="w-25">ID</th>
+        <th scope="col">静かさ</th>
+        <th scope="col"></th>
+        <th scope="col"></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @volume_in_shops.each do |volume_in_shop| %>
+      <tr>
+        <td scope="row"><%= volume_in_shop.id %></td>
+        <td><%= volume_in_shop.name %></td>
+        <td>
+          <%= link_to "編集", edit_dashboard_volume_in_shop_path(volume_in_shop) %>
+          
+        </td>
+        <td>
+          <%= link_to "削除", dashboard_volume_in_shop_path(volume_in_shop), method: :delete, data: { confirm: 'Are you sure?' } %>
+        </td>
+      </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/layouts/dashboard/_sidebar.html.erb
+++ b/app/views/layouts/dashboard/_sidebar.html.erb
@@ -18,4 +18,6 @@
     <%= link_to "お店の雰囲気一覧", dashboard_shop_atmospheres_path %>
   <br>
     <%= link_to "コーヒー豆一覧", dashboard_coffee_beans_path %>
+  <br>
+    <%= link_to "静かさ一覧", dashboard_volume_in_shops_path %>
 </div>

--- a/app/views/web/search.html.erb
+++ b/app/views/web/search.html.erb
@@ -113,6 +113,18 @@
     </div>
     
     <hr>
+    
+    <div class="search-container">
+      <div class="search-name">お店の静かさ</div>
+      <%= f.collection_check_boxes(:volume_in_shop_ids, VolumeInShop.all, :id, :name, {include_hidden: false}) do |volume_in_shop| %>
+        <div class="search-checkbox">
+          <%= volume_in_shop.check_box %>
+          <%= volume_in_shop.label %>
+        </div>
+      <% end %>
+    </div>
+    
+    <hr>
     <%= f.submit :search %>
   <% end %> 
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
     resources :municipalities, except: [:new]
     resources :shop_atmospheres, except: [:new]
     resources :coffee_beans, except: [:new]
+    resources :volume_in_shops, except: [:new]
   end
   
   devise_for :users, :controllers => {

--- a/db/migrate/20211127065253_create_volume_in_shops.rb
+++ b/db/migrate/20211127065253_create_volume_in_shops.rb
@@ -1,0 +1,9 @@
+class CreateVolumeInShops < ActiveRecord::Migration[5.2]
+  def change
+    create_table :volume_in_shops do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20211127065436_create_coffee_shop_volume_in_shops.rb
+++ b/db/migrate/20211127065436_create_coffee_shop_volume_in_shops.rb
@@ -1,0 +1,10 @@
+class CreateCoffeeShopVolumeInShops < ActiveRecord::Migration[5.2]
+  def change
+    create_table :coffee_shop_volume_in_shops do |t|
+      t.integer :coffee_shop_id
+      t.integer :volume_in_shop_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_24_113551) do
+ActiveRecord::Schema.define(version: 2021_11_27_065436) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -62,6 +62,13 @@ ActiveRecord::Schema.define(version: 2021_11_24_113551) do
   create_table "coffee_shop_shop_atmospheres", force: :cascade do |t|
     t.integer "coffee_shop_id"
     t.integer "shop_atmosphere_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "coffee_shop_volume_in_shops", force: :cascade do |t|
+    t.integer "coffee_shop_id"
+    t.integer "volume_in_shop_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
@@ -185,6 +192,12 @@ ActiveRecord::Schema.define(version: 2021_11_24_113551) do
     t.integer "best_shop_id"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+  end
+
+  create_table "volume_in_shops", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
 end

--- a/test/fixtures/coffee_shop_volume_in_shops.yml
+++ b/test/fixtures/coffee_shop_volume_in_shops.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  coffee_shop_id: 1
+  volume_in_shop_id: 1
+
+two:
+  coffee_shop_id: 1
+  volume_in_shop_id: 1

--- a/test/fixtures/volume_in_shops.yml
+++ b/test/fixtures/volume_in_shops.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+
+two:
+  name: MyString

--- a/test/models/coffee_shop_volume_in_shop_test.rb
+++ b/test/models/coffee_shop_volume_in_shop_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class CoffeeShopVolumeInShopTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/volume_in_shop_test.rb
+++ b/test/models/volume_in_shop_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class VolumeInShopTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# 背景
- この機能が必要な理由
ユーザーがお店の静かさから店舗を検索するため

- どういう機能なのか
店舗情報にお店の静かさが登録できる
お店の静かさから検索ができる

- なぜこのPR単位なのか
お店の静かさでまとめるため

# やったこと
## コードベース
- 設計方針
お店の静かさは管理画面で編集できる
コーヒーショップと多対多の関係になるので、中間テーブルを用いて紐づける

- model
静かさのテーブルと中間テーブルを作成

- controller
静かさの編集をするために静かさ用のコントローラーを作成

- view
管理画面のサイドバーから静かさの一覧を表示でき、そこから登録等が行えるように

# 画面レイアウト
- 静かさ一覧
![image](https://user-images.githubusercontent.com/87374457/143675060-0df8d8be-f7bf-4220-9b8f-9883f5223982.png)

- 検索画面
![image](https://user-images.githubusercontent.com/87374457/143675064-a76cd139-dfd7-456f-a8d0-b1ddbf118269.png)

# 検証内容
- [x] 静かさの登録ができるか
- [x] 静かさの編集ができるか
- [x] 静かさの削除ができるか
- [x] 空白の名称は登録できないか
- [x] 店舗情報に静かさを登録できるか
- [x] 店舗情報の静かさを変更できるか
- [x] 静かさ検索ができるか