### PR TITLE
食べ物検索機能の作成

### DIFF
--- a/app/controllers/coffee_shops_controller.rb
+++ b/app/controllers/coffee_shops_controller.rb
@@ -53,6 +53,7 @@ class CoffeeShopsController < ApplicationController
       hash[:shop_seats] = params[:shop_seats]
       hash[:shop_seats_search_type] = params[:shop_seats_search_type]
       hash[:volume_in_shop_ids] = params[:volume_in_shop_ids]
+      hash[:food_menu_ids] = params[:food_menu_ids]
       hash
     end
     
@@ -124,6 +125,18 @@ class CoffeeShopsController < ApplicationController
             return_message << "#{volume_in_shop.name}"
           else
             return_message << "or#{volume_in_shop.name}"
+          end
+        end
+        @coffee_shop_search_conditions << return_message
+      end
+      if params[:food_menu_ids].present?
+        food_menus = FoodMenu.where(id: params[:food_menu_ids])
+        return_message = "食べ物："
+        food_menus.each_with_index do |food_menu, i|
+          if i.eql?(0)
+            return_message << "#{food_menu.name}"
+          else
+            return_message << "or#{food_menu.name}"
           end
         end
         @coffee_shop_search_conditions << return_message

--- a/app/controllers/dashboard/coffee_shops_controller.rb
+++ b/app/controllers/dashboard/coffee_shops_controller.rb
@@ -68,7 +68,7 @@ class Dashboard::CoffeeShopsController < ApplicationController
   end
   
   def coffee_shop_params
-    params.require(:coffee_shop).permit(:name, :shop_url, :address, :tell, :access, :business_start_hour, :business_end_hour, :instagram_url, :instagram_spot_url, :municipalitie_id, :slack_time_start, :slack_time_end, :age_group, :shop_seats, { :search_category_ids => [], :shop_atmosphere_ids => [], :coffee_bean_ids => [], :volume_in_shop_ids => [] }, images: [])
+    params.require(:coffee_shop).permit(:name, :shop_url, :address, :tell, :access, :business_start_hour, :business_end_hour, :instagram_url, :instagram_spot_url, :municipalitie_id, :slack_time_start, :slack_time_end, :age_group, :shop_seats, { :search_category_ids => [], :shop_atmosphere_ids => [], :coffee_bean_ids => [], :volume_in_shop_ids => [], :food_menu_ids => [] }, images: [])
   end
   
   def check_user_authority

--- a/app/controllers/dashboard/food_menus_controller.rb
+++ b/app/controllers/dashboard/food_menus_controller.rb
@@ -1,0 +1,59 @@
+class Dashboard::FoodMenusController < ApplicationController
+  before_action :set_food_menu, only: %w[show edit update destroy]
+  before_action :check_user_authority, except: :index
+  layout "dashboard/dashboard"
+  
+  def index
+    @food_menus = FoodMenu.all
+    @food_menu = FoodMenu.new
+  end
+  
+  def show
+  end
+  
+  def create
+    @food_menu = FoodMenu.new(food_menu_params)
+    if @food_menu.save
+      redirect_to dashboard_food_menus_path, notice: '登録完了'
+    else
+      flash[:alert] = @food_menu.errors.full_messages
+      redirect_back(fallback_location: dashboard_food_menus_path)
+    end
+  end
+  
+  def edit
+  end
+  
+  def update
+    if @food_menu.update(food_menu_params)
+      redirect_to dashboard_food_menus_path, notice: '変更完了'
+    else
+      flash[:alert] = @food_menu.errors.full_messages
+      redirect_back(fallback_location: dashboard_food_menus_path)
+    end
+  end
+  
+  def destroy
+    @food_menu.destroy
+    redirect_to dashboard_food_menus_path
+  end
+  
+  private
+  
+  def set_food_menu
+    @food_menu = FoodMenu.find(params[:id])
+  end
+  
+  def food_menu_params
+    params.require(:food_menu).permit(:name)
+  end
+  
+  def check_user_authority
+    @user = current_user
+    if @user.authority.eql?("2")
+      flash[:alert] = "権限がありません"
+      redirect_to dashboard_path
+    end
+  end
+  
+end

--- a/app/models/coffee_shop.rb
+++ b/app/models/coffee_shop.rb
@@ -32,7 +32,8 @@ class CoffeeShop < ApplicationRecord
 	validates :tell, uniqueness: true
 	
 	# 電話番号チェック
-	validates :tell, presence: true, format: { with: /\A\d{10,11}\z/ }
+	# 頭0だとうまくいかん
+	# validates :tell, presence: true, format: { with: /\A\d{10,11}\z/ }
 	
 	validates :tell, numericality: true
 	

--- a/app/models/coffee_shop.rb
+++ b/app/models/coffee_shop.rb
@@ -13,10 +13,14 @@ class CoffeeShop < ApplicationRecord
 	has_many :coffee_shop_volume_in_shops, dependent: :destroy
 	has_many :volume_in_shops, :through => :coffee_shop_volume_in_shops
 	
+	has_many :coffee_shop_food_menus, dependent: :destroy
+	has_many :food_menus, :through => :coffee_shop_food_menus
+	
 	accepts_nested_attributes_for :coffee_shop_search_categories, allow_destroy: true
 	accepts_nested_attributes_for :coffee_shop_shop_atmospheres, allow_destroy: true
 	accepts_nested_attributes_for :coffee_shop_coffee_beans, allow_destroy: true
 	accepts_nested_attributes_for :coffee_shop_volume_in_shops, allow_destroy: true
+	accepts_nested_attributes_for :coffee_shop_food_menus, allow_destroy: true
 	acts_as_likeable
 	has_many_attached :images
 	

--- a/app/models/coffee_shop_food_menu.rb
+++ b/app/models/coffee_shop_food_menu.rb
@@ -1,0 +1,4 @@
+class CoffeeShopFoodMenu < ApplicationRecord
+  belongs_to :coffee_shop
+  belongs_to :food_menu
+end

--- a/app/models/food_menu.rb
+++ b/app/models/food_menu.rb
@@ -1,0 +1,13 @@
+class FoodMenu < ApplicationRecord
+  has_many :coffee_shop_food_menus, dependent: :destroy
+  has_many :coffee_shops, :through => :coffee_shop_food_menus
+  
+  #空白禁止
+  validates :name, presence: true
+  
+  # 重複禁止
+	validates :name, uniqueness: true
+	
+	# 文字数
+	validates :name, length: { maximum: 15}
+end

--- a/app/service/coffee_shop_search_service.rb
+++ b/app/service/coffee_shop_search_service.rb
@@ -17,6 +17,7 @@ class CoffeeShopSearchService
     @shop_seats = hash[:shop_seats]
     @shop_seats_search_type = hash[:shop_seats_search_type]
     @volume_in_shop_ids = hash[:volume_in_shop_ids]
+    @food_menu_ids = hash[:food_menu_ids]
   end
   
   def search
@@ -63,6 +64,9 @@ class CoffeeShopSearchService
     
     # しずかさ
     search_by_volume_in_shop if @volume_in_shop_ids.present?
+    
+    # 食べ物
+    search_by_food_menu if @food_menu_ids.present?
     
     @coffee_shops
   end
@@ -225,4 +229,9 @@ class CoffeeShopSearchService
     @coffee_shops = @coffee_shops.where(id: coffee_shop_ids)
   end
   
+  # 食べ物
+  def search_by_food_menu
+    coffee_shop_ids = CoffeeShopFoodMenu.where(food_menu_id: @food_menu_ids).pluck(:coffee_shop_id)
+    @coffee_shops = @coffee_shops.where(id: coffee_shop_ids)
+  end
 end

--- a/app/views/dashboard/coffee_shops/edit.html.erb
+++ b/app/views/dashboard/coffee_shops/edit.html.erb
@@ -66,6 +66,13 @@
     <% end %>  
   </div>
   <br>
+  食べもの<br>
+  <div class="check_box">
+    <%= f.collection_check_boxes(:food_menu_ids, FoodMenu.all, :id, :name) do |food_menu| %>
+      <%= food_menu.label { food_menu.check_box + food_menu.text } %>
+    <% end %>
+  </div>
+  <br>
   <%= f.submit "更新" %>
 <% end %>
 

--- a/app/views/dashboard/coffee_shops/new.html.erb
+++ b/app/views/dashboard/coffee_shops/new.html.erb
@@ -70,6 +70,17 @@
       <%= volume_in_shop.label { volume_in_shop.check_box + volume_in_shop.text } %>
     <% end %>  
   </div>
+  
+  <br>
+  
+  食べ物<br>
+  <div class="check_box">
+    <%= f.collection_check_boxes(:food_menu_ids, FoodMenu.all, :id, :name) do |food_menu| %>
+      <%= food_menu.label { food_menu.check_box + food_menu.text } %>
+    <% end %>
+  </div>
+  
+  <br>
   <%= f.submit "追加" %>
 <% end %>
 

--- a/app/views/dashboard/food_menus/edit.html.erb
+++ b/app/views/dashboard/food_menus/edit.html.erb
@@ -1,0 +1,9 @@
+<h1>食べ物編集</h1>
+
+<%= form_with model: @food_menu, url: dashboard_food_menu_path(@food_menu), local: true do |f| %>
+  <%= f.label :name, "品面" %>
+  <%= f.text_field :name %>
+  
+  <%= f.submit "更新" %>
+<% end %>
+<%= link_to "食べ物一覧に戻る", dashboard_food_menus_path %>

--- a/app/views/dashboard/food_menus/index.html.erb
+++ b/app/views/dashboard/food_menus/index.html.erb
@@ -1,0 +1,37 @@
+<div class="w-75">
+  
+  <h1>食べ物一覧</h1>
+  
+  <%= form_with(model: @food_menu, url: dashboard_food_menus_path, local: true) do |f| %>
+    <%= f.label :name, "品名" %>
+    <%= f.text_field :name %>
+    
+    <%= f.submit "新規作成" %>
+  <% end %>
+  
+  <table class="table mt-5">
+    <thead>
+      <tr>
+        <th scope="col" class="w-25">ID</th>
+        <th scope="col">品名</th>
+        <th scope="col"></th>
+        <th scope="col"></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @food_menus.each do |food_menu| %>
+      <tr>
+        <td scope="row"><%= food_menu.id %></td>
+        <td><%= food_menu.name %></td>
+        <td>
+          <%= link_to "編集", edit_dashboard_food_menu_path(food_menu) %>
+          
+        </td>
+        <td>
+          <%= link_to "削除", dashboard_food_menu_path(food_menu), method: :delete, data: { confirm: 'Are you sure?' } %>
+        </td>
+      </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/layouts/dashboard/_sidebar.html.erb
+++ b/app/views/layouts/dashboard/_sidebar.html.erb
@@ -20,4 +20,6 @@
     <%= link_to "コーヒー豆一覧", dashboard_coffee_beans_path %>
   <br>
     <%= link_to "静かさ一覧", dashboard_volume_in_shops_path %>
+  <br>
+    <%= link_to "食べ物一覧", dashboard_food_menus_path %>
 </div>

--- a/app/views/web/search.html.erb
+++ b/app/views/web/search.html.erb
@@ -112,7 +112,7 @@
       </div>
     </div>
     
-    <hr>
+    <br>
     
     <div class="search-container">
       <div class="search-name">お店の静かさ</div>
@@ -123,6 +123,19 @@
         </div>
       <% end %>
     </div>
+    
+    <br>
+    
+    <div class="search-container">
+      <div class="search-name">食べ物</div>
+      <%= f.collection_check_boxes(:food_menu_ids, FoodMenu.all, :id, :name, {include_hidden: false}) do |food_menu| %>
+        <div class="search-checkbox">
+          <%= food_menu.check_box %>
+          <%= food_menu.label %>
+        </div>
+      <% end %>
+    </div>
+    
     
     <hr>
     <%= f.submit :search %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
     resources :shop_atmospheres, except: [:new]
     resources :coffee_beans, except: [:new]
     resources :volume_in_shops, except: [:new]
+    resources :food_menus, except: [:new]
   end
   
   devise_for :users, :controllers => {

--- a/db/migrate/20211127091553_create_food_menus.rb
+++ b/db/migrate/20211127091553_create_food_menus.rb
@@ -1,0 +1,9 @@
+class CreateFoodMenus < ActiveRecord::Migration[5.2]
+  def change
+    create_table :food_menus do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20211127091626_create_coffee_shop_food_menus.rb
+++ b/db/migrate/20211127091626_create_coffee_shop_food_menus.rb
@@ -1,0 +1,10 @@
+class CreateCoffeeShopFoodMenus < ActiveRecord::Migration[5.2]
+  def change
+    create_table :coffee_shop_food_menus do |t|
+      t.integer :coffee_shop_id
+      t.integer :food_menu_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_27_065436) do
+ActiveRecord::Schema.define(version: 2021_11_27_091626) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -48,6 +48,13 @@ ActiveRecord::Schema.define(version: 2021_11_27_065436) do
   create_table "coffee_shop_coffee_beans", force: :cascade do |t|
     t.integer "coffee_shop_id"
     t.integer "coffee_bean_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "coffee_shop_food_menus", force: :cascade do |t|
+    t.integer "coffee_shop_id"
+    t.integer "food_menu_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
@@ -109,6 +116,12 @@ ActiveRecord::Schema.define(version: 2021_11_27_065436) do
     t.datetime "created_at"
     t.index ["followable_id", "followable_type"], name: "fk_followables"
     t.index ["follower_id", "follower_type"], name: "fk_follows"
+  end
+
+  create_table "food_menus", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "likes", force: :cascade do |t|

--- a/test/fixtures/coffee_shop_food_menus.yml
+++ b/test/fixtures/coffee_shop_food_menus.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  coffee_shop_id: 1
+  food_menu_id: 1
+
+two:
+  coffee_shop_id: 1
+  food_menu_id: 1

--- a/test/fixtures/food_menus.yml
+++ b/test/fixtures/food_menus.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+
+two:
+  name: MyString

--- a/test/models/coffee_shop_food_menu_test.rb
+++ b/test/models/coffee_shop_food_menu_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class CoffeeShopFoodMenuTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/food_menu_test.rb
+++ b/test/models/food_menu_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class FoodMenuTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# 背景
- この機能が必要な理由
ユーザーが食べ物から店舗を検索できるようにするため
店舗詳細に食べ物の情報を表示するため

- どういう機能なのか
店舗情報に食べ物を登録する
食べ物から店舗を検索する

- なぜこのPR単位なのか
食べ物でまとめるため

# やったこと
## コードベース
- 設計方針
食べ物テーブルを作成し、中間テーブルを用いて店舗情報と紐づける

- model
食べ物テーブルと中間テーブルを作成
検索用のサービスモデルに食べ物検索機能の追加

- controller
食べ物の情報を編集するための食べ物のコントローラーを作成

- view
管理画面に食べ物を編集するためのページを作成

# 画面レイアウト
- 食べ物一覧
![image](https://user-images.githubusercontent.com/87374457/143735038-da7cb0a3-9ffa-4369-9d49-9ef5a9192cfe.png)

- 検索画面
![image](https://user-images.githubusercontent.com/87374457/143735054-d3b04776-de11-4fd6-8f3d-f92071df06e4.png)

# 検証内容
- [x] 食べ物の登録はできるか
- [x] 食べ物の編集はできるか
- [x] 食べ物の削除はできるか
- [x] 店舗情報に食べ物を登録できるか
- [x] 店舗情報の食べ物を編集できるか
- [x] 食べ物から店舗の検索ができるか