### PR TITLE
ページネーションを追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,8 +51,11 @@ gem 'pry-rails'
 # エラーメッセージを日本語化できる
 gem 'rails-i18n'
 
- # socialiizatioinを使用できる
- gem 'socialization'
+# socialiizatioinを使用できる
+gem 'socialization'
+
+# ページネーションを実装できる
+gem 'kaminari'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,6 +105,18 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    kaminari (1.2.1)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.1)
+      kaminari-activerecord (= 1.2.1)
+      kaminari-core (= 1.2.1)
+    kaminari-actionview (1.2.1)
+      actionview
+      kaminari-core (= 1.2.1)
+    kaminari-activerecord (1.2.1)
+      activerecord
+      kaminari-core (= 1.2.1)
+    kaminari-core (1.2.1)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -249,6 +261,7 @@ DEPENDENCIES
   dotenv-rails
   jbuilder (~> 2.5)
   jquery-rails
+  kaminari
   listen (>= 3.0.5, < 3.2)
   pry-rails
   puma (~> 3.11)

--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -49,3 +49,7 @@ h3, .h3 {
   margin-top: 40px;
   height: 55px;
 }
+
+.pagination {
+  color: #CC935B;
+}

--- a/app/assets/stylesheets/web.scss
+++ b/app/assets/stylesheets/web.scss
@@ -164,4 +164,3 @@
   width: fit-content;
   display: inline-block;
 }
-

--- a/app/controllers/dashboard/coffee_shops_controller.rb
+++ b/app/controllers/dashboard/coffee_shops_controller.rb
@@ -20,7 +20,6 @@ class Dashboard::CoffeeShopsController < ApplicationController
 
   def new
     @coffee_shop = CoffeeShop.new
-    
     set_municipality_tags
   end
 
@@ -52,6 +51,7 @@ class Dashboard::CoffeeShopsController < ApplicationController
 
   def destroy
     @coffee_shop.destroy
+    delete_user_best_shop
     redirect_to dashboard_coffee_shops_url
   end
   
@@ -78,6 +78,13 @@ class Dashboard::CoffeeShopsController < ApplicationController
 			flash[:alert] = "権限がありません"
 			redirect_to dashboard_path 
 		end
+  end
+  
+  def delete_user_best_shop
+    users = User.where(best_shop_id: @coffee_shop.id) 
+    users.each do |user|
+      user.update(best_shop_id: "")
+    end
   end
   
 end

--- a/app/controllers/dashboard/coffee_shops_controller.rb
+++ b/app/controllers/dashboard/coffee_shops_controller.rb
@@ -2,15 +2,16 @@ class Dashboard::CoffeeShopsController < ApplicationController
   before_action :set_coffee_shop, only: %w[show edit update destroy]
   before_action :check_user_authority, only: :destroy
   layout "dashboard/dashboard"
+  PER = 15
   
   def index
     if params[:keyword].present?
       keyword = params[:keyword].strip
       @total_count = CoffeeShop.search_for_name_and_tell(keyword).count
-      @coffee_shops = CoffeeShop.search_for_name_and_tell(keyword)
+      @coffee_shops = CoffeeShop.search_for_name_and_tell(keyword).page(params[:page]).per(PER)
     else
       @total_count = CoffeeShop.count
-      @coffee_shops = CoffeeShop.all
+      @coffee_shops = CoffeeShop.page(params[:page]).per(PER)
     end
   end
   

--- a/app/controllers/dashboard/users_controller.rb
+++ b/app/controllers/dashboard/users_controller.rb
@@ -2,13 +2,14 @@ class Dashboard::UsersController < ApplicationController
   before_action :set_user, only: %w[edit update destroy]
   before_action :check_user_authority
   layout "dashboard/dashboard"
+  PER = 15
   
   def index
     if params[:keyword].present?
       @keyword = params[:keyword].strip
-      @users = User.search_information(@keyword).all
+      @users = User.search_information(@keyword).page(params[:page]).per(PER)
     else
-      @users = User.all
+      @users = User.page(params[:page]).per(PER)
     end
   end
   

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -2,7 +2,6 @@ class ReviewsController < ApplicationController
   def create
     coffee_shop = CoffeeShop.find(params[:coffee_shop_id])
     review = coffee_shop.review_new
-    # if review_params[:review_score].to_i <= 100 && review_params[:review_score].to_i >= 0
     if review.save_review(review,review_params)
       redirect_to coffee_shop_url(coffee_shop)
     else

--- a/app/models/coffee_shop.rb
+++ b/app/models/coffee_shop.rb
@@ -49,6 +49,7 @@ class CoffeeShop < ApplicationRecord
 	
 	# 開始時間と終了時間
 	validate :business_start_hour_and_business_end_hour_must_be_set
+	validate :slack_time_start_and_slack_time_end_must_be_set
 	
 	scope :search_for_name_and_tell, -> (keyword) {
 		where("name LIKE ?", "%#{keyword}%").
@@ -77,8 +78,14 @@ class CoffeeShop < ApplicationRecord
 		end
 	end
 	
-	# def start_time_and_end_time_must_be_set
+	def slack_time_start_and_slack_time_end_must_be_set
+		return if slack_time_start.nil? && slack_time_end.nil?
 		
-	# end
+		if slack_time_start.nil?
+			errors.add(:slack_time_start, "はすいている時間(終了)とペアで入力してください。")
+		elsif	slack_time_end.nil?
+			errors.add(:slack_time_end, "はすいている時間(開始)とペアで入力してください。")
+		end
+	end
 	
 end

--- a/app/service/create_coffee_shop_search_conditions_service.rb
+++ b/app/service/create_coffee_shop_search_conditions_service.rb
@@ -1,7 +1,7 @@
 class CreateCoffeeShopSearchConditionsService
   def initialize(hash)
     @name = hash[:name]
-    @tell = hash[:shop_tell]
+    @shop_tell = hash[:shop_tell]
     @search_category_ids = hash[:search_category_ids]
     @review_score = hash[:review_score]
     @review_score_search_type = hash[:review_score_search_type]
@@ -24,6 +24,20 @@ class CreateCoffeeShopSearchConditionsService
     @coffee_shop_search_conditions= []
     
     create_name if @name.present?
+    create_shop_tell if @shop_tell.present?
+    create_search_category if @search_category_ids.present?
+    create_review_score if @review_score.present?
+    create_review_count if @review_count.present?
+    create_favorite_count if @favorite_count.present?
+    create_municipality if @municipality_id.present?
+    create_business_hour if @business_hour.present?
+    create_slack_time if @slack_time.present?
+    create_age_group if @age_group.present?
+    create_shop_atmosphere if @shop_atmosphere_ids.present?
+    create_shop_seats if @shop_seats.present?
+    create_volume_in_shop if @volume_in_shop_ids.present?
+    create_food_menu if @food_menu_ids.present?
+    
     
     @coffee_shop_search_conditions
   end
@@ -32,82 +46,74 @@ class CreateCoffeeShopSearchConditionsService
     @coffee_shop_search_conditions << "店舗名：#{@name}"
   end
   
-  def set_coffee_shop_search_conditions(hash)
-      @coffee_shop_search_conditions = []
-      @coffee_shop_search_conditions << "店舗名：#{params[:name]}" if params[:name].present?
-      @coffee_shop_search_conditions << "電話番号：#{params[:tel]}" if params[:tell].present?
-      if params[:search_category_ids].present?
-        search_categorys = SearchCategory.where(id: params[:search_category_ids])
-        return_message = "こだわり：#{search_categorys.pluck(:name).join('or')}"
-        @coffee_shop_search_conditions << return_message
-      end
-      if params[:review_score].present?
-        @coffee_shop_search_conditions << "レビュー点数：#{params[:review_score]}点以上" if params[:review_score_search_type].eql?("more_than")
-        @coffee_shop_search_conditions << "レビュー点数：#{params[:review_score]}点以下" if params[:review_score_search_type].eql?("less_than")
-      end
-      if params[:review_count].present?
-        @coffee_shop_search_conditions << "レビュー数：#{params[:review_count]}件以上" if params[:review_count_search_type].eql?("more_than")
-        @coffee_shop_search_conditions << "レビュー数：#{params[:review_count]}件以下" if params[:review_count_search_type].eql?("less_than")
-      end
-      if params[:favorite_count].present?
-        @coffee_shop_search_conditions << "お気に入り数：#{params[:favorite_count]}件以上" if params[:favorite_count_search_type].eql?("more_than")
-        @coffee_shop_search_conditions << "お気に入り数：#{params[:favorite_count]}件以下" if params[:favorite_count_search_type].eql?("less_than")
-      end
-      @coffee_shop_search_conditions << "エリア：#{Municipality.find(params[:municipality_id]).name}" if params[:municipality_id].present?
-      @coffee_shop_search_conditions << "営業時間：#{params[:business_hour]}" if params[:business_hour].present?
-      @coffee_shop_search_conditions << "すいている時間：#{params[:slack_time]}" if params[:slack_time].present?
-      @coffee_shop_search_conditions << "年齢層：#{params[:age_group]}" if params[:age_group].present?
-      if params[:shop_atmosphere_ids].present?
-        shop_atmospheres = ShopAtmosphere.where(id: params[:shop_atmosphere_ids])
-        return_message = "お店の雰囲気："
-        shop_atmospheres.each_with_index do |shop_atmospere, i|
-          if i.eql?(0)
-            return_message << "#{shop_atmospere.name}"
-          else
-            return_message << "or#{shop_atmospere.name}"
-          end
-        end
-        @coffee_shop_search_conditions << return_message
-      end
-      if params[:coffee_bean_ids].present?
-        coffee_beans = CoffeeBean.where(id: params[:coffee_bean_ids])
-        return_message = "コーヒー豆："
-        coffee_beans.each_with_index do |coffee_bean, i|
-          if i.eql?(0)
-            return_message << "#{coffee_bean.name}"
-          else
-            return_message << "or#{coffee_bean.name}"
-          end
-        end
-        @coffee_shop_search_conditions << return_message
-      end
-      if params[:shop_seats].present?
-        @coffee_shop_search_conditions << "席数：#{params[:shop_seats]}席以上" if params[:shop_seats_search_type].eql?("more_than") 
-        @coffee_shop_search_conditions << "席数：#{params[:shop_seats]}席以下" if params[:shop_seats_search_type].eql?("less_than")
-      end
-      if params[:volume_in_shop_ids].present?
-        volume_in_shops = VolumeInShop.where(id: params[:volume_in_shop_ids])
-        return_message = "静かさ："
-        volume_in_shops.each_with_index do |volume_in_shop, i|
-          if i.eql?(0)
-            return_message << "#{volume_in_shop.name}"
-          else
-            return_message << "or#{volume_in_shop.name}"
-          end
-        end
-        @coffee_shop_search_conditions << return_message
-      end
-      if params[:food_menu_ids].present?
-        food_menus = FoodMenu.where(id: params[:food_menu_ids])
-        return_message = "食べ物："
-        food_menus.each_with_index do |food_menu, i|
-          if i.eql?(0)
-            return_message << "#{food_menu.name}"
-          else
-            return_message << "or#{food_menu.name}"
-          end
-        end
-        @coffee_shop_search_conditions << return_message
-      end
-    end
+  def create_shop_tell
+    @coffee_shop_search_conditions << "電話番号：#{@shop_tell}"
   end
+  
+  def create_search_category
+    search_categorys = SearchCategory.where(id: @search_category_ids)
+    return_message = "こだわり：#{search_categorys.pluck(:name).join('or')}"
+    @coffee_shop_search_conditions << return_message
+  end
+  
+  def create_review_score
+    @coffee_shop_search_conditions << "レビュー点数：#{@review_score}点以上" if @review_score_search_type.eql?("more_than")
+    @coffee_shop_search_conditions << "レビュー点数：#{@review_score}点以下" if @review_score_search_type.eql?("less_than")
+  end
+  
+  def create_review_count
+    @coffee_shop_search_conditions << "レビュー数：#{@review_count}件以上" if @review_count_search_type.eql?("more_than")
+    @coffee_shop_search_conditions << "レビュー数：#{@review_count}件以下" if @review_count_search_type.eql?("less_than")
+  end
+  
+  def create_favorite_count
+    @coffee_shop_search_conditions << "お気に入り数：#{@favorite_count}件以上" if @favorite_count_search_type.eql?("more_than")
+    @coffee_shop_search_conditions << "お気に入り数：#{@favorite_count}件以下" if @favorite_count_search_type.eql?("less_than")
+  end
+  
+  def create_municipality
+    @coffee_shop_search_conditions << "エリア：#{Municipality.find(@municipality_id).name}" 
+  end
+    
+  def create_business_hour
+    @coffee_shop_search_conditions << "営業時間：#{@business_hour}"
+  end
+  
+  def create_slack_time
+    @coffee_shop_search_conditions << "すいている時間：#{@slack_time}"
+  end
+  
+  def create_age_group
+    @coffee_shop_search_conditions << "年齢層：#{@age_group}"
+  end
+  
+  def create_shop_atmosphere
+    shop_atmospheres = ShopAtmosphere.where(id: @shop_atmosphere_ids)
+    return_message = "お店の雰囲気：#{shop_atmospheres.pluck(:name).join('or')}"
+    @coffee_shop_search_conditions << return_message
+  end
+  
+  def create_coffee_bean
+    coffee_beans = CoffeeBean.where(id: params[:coffee_bean_ids])
+    return_message = "コーヒー豆：#{coffee_beans.pluck(:name).join('or')}"
+    @coffee_shop_search_conditions << return_message
+  end
+  
+  def create_shop_seats
+    @coffee_shop_search_conditions << "席数：#{@shop_seats}席以上" if @shop_seats_search_type.eql?("more_than") 
+    @coffee_shop_search_conditions << "席数：#{@shop_seats}席以下" if @shop_seats_search_type.eql?("less_than")
+  end
+  
+  def create_volume_in_shop
+    volume_in_shops = VolumeInShop.where(id: @volume_in_shop_ids)
+    return_message = "静かさ：#{volume_in_shops.pluck(:name).join('or')}"
+    @coffee_shop_search_conditions << return_message
+  end
+  
+  def create_food_menu
+    food_menus = FoodMenu.where(id: @food_menu_ids)
+    return_message = "食べ物：#{food_menus.pluck(:name).join('or')}"
+    @coffee_shop_search_conditions << return_message
+  end
+  
+end

--- a/app/views/coffee_shops/search.html.erb
+++ b/app/views/coffee_shops/search.html.erb
@@ -7,7 +7,7 @@
     <% end %>
   </div>
   <hr>
-  全<%= @coffee_shops.count %>件<br>
+  全<%= @coffee_shops_count %>件<br>
   <% if @coffee_shops.blank? %>
     該当店舗なし
     <br>
@@ -43,5 +43,6 @@
       </div>
       <hr>
     <% end %>
+    <%= paginate @coffee_shops %>
   <% end %>
 </div>

--- a/app/views/coffee_shops/show.html.erb
+++ b/app/views/coffee_shops/show.html.erb
@@ -98,7 +98,7 @@
 	  </div>
 		<div class="review-totel-container">
 			<div class="review-totel-count">
-				<%= @reviews.count %>
+				<%= @reviews_count %>
 				<p>件</p>
 			</div>
 			<div class="review-totel-score">
@@ -123,6 +123,8 @@
 				<% end %>
 			</div>
 		<%end %>
+		
+		<%= paginate @reviews %>
 		
 		<% if user_signed_in? %>
 			<div class="offset-md-5 col-md-5">

--- a/app/views/coffee_shops/show.html.erb
+++ b/app/views/coffee_shops/show.html.erb
@@ -128,16 +128,19 @@
 		
 		<% if user_signed_in? %>
 			<div class="offset-md-5 col-md-5">
+				<p>レビューを書く</p>
 				<%= form_with model: @review, url: coffee_shop_reviews_path(@coffee_shop) do |f| %>
 					<%= f.file_field :image, { onChange: "javascript: handleImage(this.files);"} %>
 					<img id="review-image-preview",size="50x50">
-					<br>
-					レビュー内容 ※150字以内
-					<%= f.text_area :review_comment, class: "form-control m-2" %>
-					<br>
-					レビュースコア ※0~100、整数のみ
-					<%= f.number_field :review_score, class: "form-control m-2" %>
-					<%= f.submit "レビューを追加" %>
+					<div class="user-review-score">
+						満足度　※0~100の整数のみを入力してください
+						<%= f.number_field :review_score, class: "form-control m-2" %>
+					</div>
+					<div class="user-review-comment">
+						レビュー本文　※150字以内で入力してください
+						<%= f.text_area :review_comment, class: "form-control m-2" %>
+					</div>
+					<%= f.submit "書き込む" %>
 				<% end %>
 			</div>
 		<% end %>

--- a/app/views/dashboard/coffee_shops/index.html.erb
+++ b/app/views/dashboard/coffee_shops/index.html.erb
@@ -36,4 +36,5 @@
       <% end %>
     </tbody>
   </table>
+  <%= paginate @coffee_shops %>
 </div>

--- a/app/views/dashboard/users/index.html.erb
+++ b/app/views/dashboard/users/index.html.erb
@@ -46,4 +46,5 @@
       <% end %>
     </tbody>
   </table>
+  <%= paginate @users %>
 </div>

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,0 +1,3 @@
+<li class='page-item disabled'>
+  <%= link_to raw(t 'views.pagination.truncate'), '#', class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, rel: 'next', remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,0 +1,9 @@
+<% if page.current? %>
+  <li class="page-item active">
+    <%= content_tag :a, page, data: { remote: remote }, rel: page.rel, class: 'page-link' %>
+  </li>
+<% else %>
+  <li class="page-item">
+    <%= link_to page, url, remote: remote, rel: page.rel, class: 'page-link' %>
+  </li>
+<% end %>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,17 @@
+<%= paginator.render do %>
+  <nav>
+    <ul class="pagination">
+      <%= first_page_tag unless current_page.first? %>
+      <%= prev_page_tag unless current_page.first? %>
+      <% each_page do |page| %>
+        <% if page.left_outer? || page.right_outer? || page.inside_window? %>
+          <%= page_tag page %>
+        <% elsif !page.was_truncated? -%>
+          <%= gap_tag %>
+        <% end %>
+      <% end %>
+      <%= next_page_tag unless current_page.last? %>
+      <%= last_page_tag unless current_page.last? %>
+    </ul>
+  </nav>
+<% end %>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, rel: 'prev', remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -20,8 +20,8 @@
 <br>
 お気に入り店舗:<%= @show_user.likees(CoffeeShop).count %>件
 <br>
-<% @show_user.likees(CoffeeShop).each do |favorite_coffee_shop| %>
-  <%= link_to favorite_coffee_shop.name, coffee_shop_path(favorite_coffee_shop) %>|
+<% @show_user.likees(CoffeeShop).last(5).each do |favorite_coffee_shop| %>
+  <%= link_to favorite_coffee_shop.name, coffee_shop_path(favorite_coffee_shop) %>
 <%end %>
 <br>
 レビュー：<%= @reviews.count %>件

--- a/app/views/web/index.html.erb
+++ b/app/views/web/index.html.erb
@@ -49,7 +49,7 @@
       <div class="search-text">
         tell
         <br>
-        <%= f.number_field :tell %>
+        <%= f.number_field :shop_tell %>
       </div>
       <div class="search-btn">
         <%= f.submit :search %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,6 +14,9 @@ module Cafe
     config.i18n.default_locale = :ja
     
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.yml').to_s]
+    
+    config.time_zone = 'Tokyo'
+    
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/locales/kaminari_ja.yml
+++ b/config/locales/kaminari_ja.yml
@@ -1,0 +1,17 @@
+ja:
+  views:
+    pagination:
+      first: "&laquo;"
+      last: "&raquo;"
+      previous: "&lsaquo;"
+      next: "&rsaquo;"
+      truncate: "..."
+  helpers:
+    page_entries_info:
+      one_page:
+        display_entries:
+          zero: ""
+          one: "<strong>1-1</strong>/1"
+          other: "<strong>1-%{count}</strong>/%{count}"
+      more_pages:
+        display_entries: "<strong>%{first}-%{last}</strong>/%{total}"

--- a/config/locales/models/ja.yml
+++ b/config/locales/models/ja.yml
@@ -18,6 +18,9 @@ ja:
         instagram_url: Instagram公式URL
         instagram_spot_url: InstagramスポットURL
         municipalitie_id: エリアid
+        slack_time_start: すいている時間(開始) 
+        slack_time_end: すいている時間(終了)
+        shop_tell: 電話番号
         
       user:
         name: ユーザー名


### PR DESCRIPTION
# 背景
- この機能が必要な理由
表示するコンテンツの数が多かった時にページを分けて見やすくするため

- どういう機能なのか
表示するコンテンツを15個ごとに表示する。
それ以降の項目が見たい場合は、次へを押す

- なぜこのPR単位なのか
ページネーションの機能でまとめるため

# やったこと
## コードベース
- 設計方針
gem`kaminari`を使用する
[https://github.com/kaminari/kaminari](https://github.com/kaminari/kaminari)

ユーザー、店舗情報、レビューに対して実装する
お気に入りやフォロワーは違うGemを使っているため、今回のGemが使えないので、
後日表示方法について考える

- model
変更なし

- controller
15個ごとにページネーションする設定を追加

- view
次のコンテンツや前のコンテンツに切り替えるボタンを追加

# 画面レイアウト
- 店舗一覧
![image](https://user-images.githubusercontent.com/87374457/145031013-3f22cab7-1f8a-4ab2-a41c-b5884dd15ab5.png)

- 検索結果
![image](https://user-images.githubusercontent.com/87374457/145030907-04b4a416-e3bb-4c27-a1df-d08757dd6413.png)

- レビュー
![image](https://user-images.githubusercontent.com/87374457/145031488-68a204e7-0547-4740-bef0-9881f93d593c.png)

# 検証内容
- [x] 次ページのボタンが表示されているか
- [x] 次ページのボタンが機能するか
- [x] 前ページのボタンが表示されているか
- [x] 前ページのボタンが機能するか
- [x] コンテンツの数が15個以内の時は次ページのボタン等は非表示になっているか