### PR TITLE
PC作業を店舗情報に追加

### DIFF
--- a/app/controllers/coffee_shops_controller.rb
+++ b/app/controllers/coffee_shops_controller.rb
@@ -78,6 +78,7 @@ class CoffeeShopsController < ApplicationController
       hash[:volume_in_shop_ids] = params[:volume_in_shop_ids]
       hash[:food_menu_ids] = params[:food_menu_ids]
       hash[:shop_bgm_ids] = params[:shop_bgm_ids]
+      hash[:pc_work] = params[:pc_work]
       hash
     end
 end

--- a/app/controllers/dashboard/coffee_shops_controller.rb
+++ b/app/controllers/dashboard/coffee_shops_controller.rb
@@ -8,10 +8,10 @@ class Dashboard::CoffeeShopsController < ApplicationController
     if params[:keyword].present?
       keyword = params[:keyword].strip
       @total_count = CoffeeShop.search_for_name_and_tell(keyword).count
-      @coffee_shops = CoffeeShop.search_for_name_and_tell(keyword).page(params[:page]).per(PER)
+      @coffee_shops = CoffeeShop.search_for_name_and_tell(keyword).order("created_at DESC").page(params[:page]).per(PER)
     else
       @total_count = CoffeeShop.count
-      @coffee_shops = CoffeeShop.page(params[:page]).per(PER)
+      @coffee_shops = CoffeeShop.order("created_at DESC").page(params[:page]).per(PER)
     end
   end
   
@@ -69,7 +69,7 @@ class Dashboard::CoffeeShopsController < ApplicationController
   end
   
   def coffee_shop_params
-    params.require(:coffee_shop).permit(:name, :shop_url, :address, :shop_tell, :access, :business_start_hour, :business_end_hour, :instagram_url, :instagram_spot_url, :municipalitie_id, :slack_time_start, :slack_time_end, :age_group, :shop_seats, { :search_category_ids => [], :shop_atmosphere_ids => [], :coffee_bean_ids => [], :volume_in_shop_ids => [], :food_menu_ids => [] ,:shop_bgm_ids => [] }, images: [])
+    params.require(:coffee_shop).permit(:name, :shop_url, :address, :shop_tell, :access, :business_start_hour, :business_end_hour, :instagram_url, :instagram_spot_url, :municipalitie_id, :slack_time_start, :slack_time_end, :age_group, :shop_seats, :pc_work, { :search_category_ids => [], :shop_atmosphere_ids => [], :coffee_bean_ids => [], :volume_in_shop_ids => [], :food_menu_ids => [] ,:shop_bgm_ids => [] }, images: [])
   end
   
   def check_user_authority

--- a/app/models/pc_work.rb
+++ b/app/models/pc_work.rb
@@ -1,0 +1,2 @@
+class PcWork < ApplicationRecord
+end

--- a/app/service/coffee_shop_search_service.rb
+++ b/app/service/coffee_shop_search_service.rb
@@ -19,6 +19,7 @@ class CoffeeShopSearchService
     @volume_in_shop_ids = hash[:volume_in_shop_ids]
     @food_menu_ids = hash[:food_menu_ids]
     @shop_bgm_ids = hash[:shop_bgm_ids]
+    @pc_work = hash[:pc_work]
   end
   
   def search
@@ -71,6 +72,9 @@ class CoffeeShopSearchService
     
     # BGM
     search_by_shop_bgm if @shop_bgm_ids.present?
+    
+    # PC作業
+    search_by_pc_work if @pc_work.present?
     
     @coffee_shops
   end
@@ -243,5 +247,10 @@ class CoffeeShopSearchService
   def search_by_shop_bgm
     coffee_shop_ids = CoffeeShopShopBgm.where(shop_bgm_id: @shop_bgm_ids).pluck(:coffee_shop_id)
     @coffee_shops = @coffee_shops.where(id: coffee_shop_ids)
+  end
+  
+  # PC作業
+  def search_by_pc_work
+    @coffee_shops = @coffee_shops.where(pc_work: @pc_work)
   end
 end

--- a/app/service/create_coffee_shop_search_conditions_service.rb
+++ b/app/service/create_coffee_shop_search_conditions_service.rb
@@ -19,6 +19,7 @@ class CreateCoffeeShopSearchConditionsService
     @volume_in_shop_ids = hash[:volume_in_shop_ids]
     @food_menu_ids = hash[:food_menu_ids]
     @shop_bgm_ids = hash[:shop_bgm_ids]
+    @pc_work = hash[:pc_work]
   end
   
   def create
@@ -39,6 +40,7 @@ class CreateCoffeeShopSearchConditionsService
     create_volume_in_shop if @volume_in_shop_ids.present?
     create_food_menu if @food_menu_ids.present?
     create_shop_bgm if @shop_bgm_ids.present?
+    create_pc_work if @pc_work.present?
     
     @coffee_shop_search_conditions
   end
@@ -121,6 +123,10 @@ class CreateCoffeeShopSearchConditionsService
     shop_bgms = ShopBgm.where(id: @shop_bgm_ids)
     return_message = "BGM：#{shop_bgms.pluck(:name).join('or')}"
     @coffee_shop_search_conditions << return_message
+  end
+  
+  def create_pc_work
+    @coffee_shop_search_conditions << "PC作業：#{@pc_work}"
   end
   
 end

--- a/app/views/coffee_shops/show.html.erb
+++ b/app/views/coffee_shops/show.html.erb
@@ -80,6 +80,10 @@
 	  			<th>BGM</th>
 	  			<td><%= @shop_bgm %></td>
 	  		</tr>
+	  		<tr>
+	  			<th>PC作業</th>
+	  			<td><%= @coffee_shop.pc_work %></td>
+	  		</tr>
 	  	</tbody>
 	  </table>
 	  <div class="liker-container">

--- a/app/views/dashboard/coffee_shops/edit.html.erb
+++ b/app/views/dashboard/coffee_shops/edit.html.erb
@@ -3,30 +3,41 @@
 <%= form_with model: @coffee_shop, url: dashboard_coffee_shop_path, local: true do |f| %>
   店舗名<%= f.text_field :name %>
   <br>
+  
   店舗HP<%= f.text_field :shop_url %>
   <br>
+  
   住所<%= f.text_field :address %>
   <br>
+  
   電話番号<%= f.number_field :shop_tell %>
   <br>
+  
   アクセス<%= f.text_field :access %>
   <br>
+  
   営業時間<%= f.time_field :business_start_hour %> ~ <%= f.time_field :business_end_hour %>
   <br>
+  
   すいている時間<%= f.time_field :slack_time_start %> ~ <%= f.time_field :slack_time_end %>
   <br>
+  
   定休日
   <% DayOfWeek.all.each do |day_of_week| %>
     <%= check_box_tag 'regular_holidays[]', day_of_week.name, @coffee_shop.regular_holiday.include?(day_of_week.name) %><%= day_of_week.name %>
   <% end %>
   <br>
+  
   年齢層
   <%= f.select :age_group, AgeGroup.pluck(:name), { include_blank: '選択してください' } %>
   <br>
+  
   Instagram公式URL<%= f.text_field :instagram_url %>
   <br>
+  
   InstagramスポットURL<%= f.text_field :instagram_spot_url %>
   <br>
+  
   エリア<%= f.select :municipalitie_id, @municipality_tags, { include_blank: '選択してください' } %>
   <br>
   <div class="form-inline mt-4 mb-4 row">
@@ -38,47 +49,54 @@
       <img id="image-preview",size="50x50">
     </div>
   </div>
-  <br>
+  
   検索カテゴリ<br>
   <div class="check_box">
     <%= f.collection_check_boxes(:search_category_ids, SearchCategory.all, :id, :name) do |search_category| %>
       <%= search_category.label { search_category.check_box + search_category.text } %>
     <% end %>
   </div>
+  
   お店の雰囲気<br>
   <div class="check_box">
     <%= f.collection_check_boxes(:shop_atmosphere_ids, ShopAtmosphere.all, :id, :name) do |shop_atmosphere| %>
       <%= shop_atmosphere.label { shop_atmosphere.check_box + shop_atmosphere.text } %>
     <% end %>
   </div>
+  
   コーヒー豆<br>
   <div class="check_box">
     <%= f.collection_check_boxes(:coffee_bean_ids, CoffeeBean.all, :id, :name) do |coffee_bean| %>
       <%= coffee_bean.label { coffee_bean.check_box + coffee_bean.text } %>
     <% end %>
   </div>
+  
   席数<%= f.number_field :shop_seats %>
   <br>
+  
   静かさ<br>
   <div class="check_box">
     <%= f.collection_check_boxes(:volume_in_shop_ids, VolumeInShop.all, :id, :name) do |volume_in_shop| %>
       <%= volume_in_shop.label { volume_in_shop.check_box + volume_in_shop.text } %>
     <% end %>  
   </div>
-  <br>
+  
   食べもの<br>
   <div class="check_box">
     <%= f.collection_check_boxes(:food_menu_ids, FoodMenu.all, :id, :name) do |food_menu| %>
       <%= food_menu.label { food_menu.check_box + food_menu.text } %>
     <% end %>
   </div>
-  <br>
+  
   BGM<br>
   <div class="check_box">
     <%= f.collection_check_boxes(:shop_bgm_ids, ShopBgm.all, :id, :name) do |shop_bgm| %>
       <%= shop_bgm.label { shop_bgm.check_box + shop_bgm.text } %>
     <% end %>
   </div>
+  
+  PC作業<br>
+  <%= f.select :pc_work, PcWork.pluck(:name), { include_blank: '選択してください' } %>
   <br>
   <%= f.submit "更新" %>
 <% end %>

--- a/app/views/dashboard/coffee_shops/new.html.erb
+++ b/app/views/dashboard/coffee_shops/new.html.erb
@@ -83,6 +83,10 @@
     <% end %>
   </div>
   
+  PC作業<br>
+  <%= f.select :pc_work, PcWork.pluck(:name), { include_blank: '選択してください' } %>
+  
+  <br>
   <%= f.submit "追加" %>
 <% end %>
 

--- a/app/views/web/search.html.erb
+++ b/app/views/web/search.html.erb
@@ -148,6 +148,13 @@
       <% end %>
     </div>
     
+    <br>
+    
+    <div class="search-container">
+      <div class="search-name">PC作業</div>
+      <%= f.select :pc_work, PcWork.pluck(:name), { include_blank: 'select' }, :class => 'search-select' %>
+    </div>
+    
     <hr>
     <%= f.submit :search %>
   <% end %> 

--- a/app/views/web/search.html.erb
+++ b/app/views/web/search.html.erb
@@ -88,17 +88,7 @@
     
     <div class="search-container">
       <div class="search-name">年齢層</div>
-      <%= f.select :age_group, AgeGroup.pluck(:name), { include_blank: 'select' }, :class => 'search-select' %>
-    </div>
-    
-    <div class="search-container">
-      <div class="search-name">コーヒー豆</div>
-      <%= f.collection_check_boxes(:coffee_bean_ids, CoffeeBean.all, :id, :name, {include_hidden: false}) do |coffee_bean| %>
-        <div class="search-checkbox">
-          <%= coffee_bean.check_box %>
-          <%= coffee_bean.label %>
-        </div>
-      <% end %>
+      <%= f.select :age_group, AgeGroup.pluck(:name), { include_blank: '未選択' }, :class => 'search-select' %>
     </div>
     
     <div class="search-container">
@@ -110,6 +100,18 @@
         <%= f.radio_button :shop_seats_search_type, :less_than %>
         <%= f.label :shop_seats_search_type, "以下", {value: :less_than, style: "display: inline-block;"} %>
       </div>
+    </div>
+    
+    <br>
+    
+    <div class="search-container">
+      <div class="search-name">コーヒー豆</div>
+      <%= f.collection_check_boxes(:coffee_bean_ids, CoffeeBean.all, :id, :name, {include_hidden: false}) do |coffee_bean| %>
+        <div class="search-checkbox">
+          <%= coffee_bean.check_box %>
+          <%= coffee_bean.label %>
+        </div>
+      <% end %>
     </div>
     
     <br>
@@ -152,7 +154,7 @@
     
     <div class="search-container">
       <div class="search-name">PC作業</div>
-      <%= f.select :pc_work, PcWork.pluck(:name), { include_blank: 'select' }, :class => 'search-select' %>
+      <%= f.select :pc_work, PcWork.pluck(:name), { include_blank: '未選択' }, :class => 'search-select' %>
     </div>
     
     <hr>

--- a/db/migrate/20211212085706_create_pc_works.rb
+++ b/db/migrate/20211212085706_create_pc_works.rb
@@ -1,0 +1,9 @@
+class CreatePcWorks < ActiveRecord::Migration[5.2]
+  def change
+    create_table :pc_works do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20211212090209_add_pc_work.rb
+++ b/db/migrate/20211212090209_add_pc_work.rb
@@ -1,0 +1,5 @@
+class AddPcWork < ActiveRecord::Migration[5.2]
+  def change
+    add_column :coffee_shops, :pc_work, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_08_102537) do
+ActiveRecord::Schema.define(version: 2021_12_12_090209) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -108,6 +108,7 @@ ActiveRecord::Schema.define(version: 2021_12_08_102537) do
     t.string "age_group"
     t.integer "shop_seats"
     t.string "shop_tell"
+    t.string "pc_work"
   end
 
   create_table "day_of_weeks", force: :cascade do |t|
@@ -155,6 +156,12 @@ ActiveRecord::Schema.define(version: 2021_12_08_102537) do
   create_table "municipalities", force: :cascade do |t|
     t.string "name"
     t.integer "prefecture_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "pc_works", force: :cascade do |t|
+    t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/test/fixtures/pc_works.yml
+++ b/test/fixtures/pc_works.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+
+two:
+  name: MyString

--- a/test/models/pc_work_test.rb
+++ b/test/models/pc_work_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class PcWorkTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# 背景
- この機能が必要な理由
ユーザーがPC作業できるかどうかで店舗を検索できるよにするため
店舗情報にPC作業できるか表示するため

- どういう機能なのか
店舗情報にPC作業ができるかを登録する
PC作業できるかで店舗を検索する

- なぜこのPR単位なのか
PC作業の可否でまとめるため

# やったこと
## コードベース
- 設計方針
PC作業できるかのテーブルを作成する
PC作業のテーブルには3つしか登録しないので、編集画面などは作成しないで、
直接データベースに登録して、追加する

- model
PC作業のテーブルを作成
検索用のテーブルにPC作業検索機能を追加

- controller
特に大きな変更はない

- view
検索項目と店舗詳細にPC作業を追加

# 画面レイアウト
- 店舗情報登録
![image](https://user-images.githubusercontent.com/87374457/145707684-444c7b82-8dbd-49ed-bc89-e518f2b94a36.png)

- 店舗詳細
![image](https://user-images.githubusercontent.com/87374457/145707702-ddf6905c-f1f6-4c37-95a0-77aabe9b9a12.png)

- 検索画面
![image](https://user-images.githubusercontent.com/87374457/145707718-47ba2957-8cd4-43f4-be31-a55b5b16ae97.png)

- 検索結果
![image](https://user-images.githubusercontent.com/87374457/145707726-c2416b6b-3622-4af0-a53a-9a6add0378e8.png)

# 検証内容
- [x] 店舗情報にPC作業可否の登録はできるか
- [x] 店舗情報のPC作業可否は変更できるか
- [x] 店舗情報詳細画面にPC作業の可否は表示されているか
- [x] 検索条件にPC作業可否は表示されているか
- [x] PC作業可否から検索ができるか