### PR TITLE
制限時間を店舗情報に追加

### DIFF
--- a/app/controllers/coffee_shops_controller.rb
+++ b/app/controllers/coffee_shops_controller.rb
@@ -79,6 +79,7 @@ class CoffeeShopsController < ApplicationController
       hash[:food_menu_ids] = params[:food_menu_ids]
       hash[:shop_bgm_ids] = params[:shop_bgm_ids]
       hash[:pc_work] = params[:pc_work]
+      hash[:time_limit] = params[:time_limit]
       hash
     end
 end

--- a/app/controllers/dashboard/coffee_shops_controller.rb
+++ b/app/controllers/dashboard/coffee_shops_controller.rb
@@ -69,7 +69,7 @@ class Dashboard::CoffeeShopsController < ApplicationController
   end
   
   def coffee_shop_params
-    params.require(:coffee_shop).permit(:name, :shop_url, :address, :shop_tell, :access, :business_start_hour, :business_end_hour, :instagram_url, :instagram_spot_url, :municipalitie_id, :slack_time_start, :slack_time_end, :age_group, :shop_seats, :pc_work, { :search_category_ids => [], :shop_atmosphere_ids => [], :coffee_bean_ids => [], :volume_in_shop_ids => [], :food_menu_ids => [] ,:shop_bgm_ids => [] }, images: [])
+    params.require(:coffee_shop).permit(:name, :shop_url, :address, :shop_tell, :access, :business_start_hour, :business_end_hour, :instagram_url, :instagram_spot_url, :municipalitie_id, :slack_time_start, :slack_time_end, :age_group, :shop_seats, :pc_work, :time_limit, { :search_category_ids => [], :shop_atmosphere_ids => [], :coffee_bean_ids => [], :volume_in_shop_ids => [], :food_menu_ids => [] ,:shop_bgm_ids => [] }, images: [])
   end
   
   def check_user_authority

--- a/app/models/time_limit.rb
+++ b/app/models/time_limit.rb
@@ -1,0 +1,2 @@
+class TimeLimit < ApplicationRecord
+end

--- a/app/service/coffee_shop_search_service.rb
+++ b/app/service/coffee_shop_search_service.rb
@@ -20,6 +20,7 @@ class CoffeeShopSearchService
     @food_menu_ids = hash[:food_menu_ids]
     @shop_bgm_ids = hash[:shop_bgm_ids]
     @pc_work = hash[:pc_work]
+    @time_limit = hash[:time_limit]
   end
   
   def search
@@ -75,6 +76,9 @@ class CoffeeShopSearchService
     
     # PC作業
     search_by_pc_work if @pc_work.present?
+    
+    # 時間制限
+    search_by_time_limit if @time_limit.present?
     
     @coffee_shops
   end
@@ -253,4 +257,10 @@ class CoffeeShopSearchService
   def search_by_pc_work
     @coffee_shops = @coffee_shops.where(pc_work: @pc_work)
   end
+  
+  # 時間制限
+  def search_by_time_limit
+    @coffee_shops = @coffee_shops.where(time_limit: @time_limit)
+  end
+  
 end

--- a/app/service/create_coffee_shop_search_conditions_service.rb
+++ b/app/service/create_coffee_shop_search_conditions_service.rb
@@ -20,6 +20,7 @@ class CreateCoffeeShopSearchConditionsService
     @food_menu_ids = hash[:food_menu_ids]
     @shop_bgm_ids = hash[:shop_bgm_ids]
     @pc_work = hash[:pc_work]
+    @time_limit = hash[:time_limit]
   end
   
   def create
@@ -41,6 +42,7 @@ class CreateCoffeeShopSearchConditionsService
     create_food_menu if @food_menu_ids.present?
     create_shop_bgm if @shop_bgm_ids.present?
     create_pc_work if @pc_work.present?
+    create_time_limit if @time_limit.present?
     
     @coffee_shop_search_conditions
   end
@@ -127,6 +129,10 @@ class CreateCoffeeShopSearchConditionsService
   
   def create_pc_work
     @coffee_shop_search_conditions << "PC作業：#{@pc_work}"
+  end
+  
+  def create_time_limit
+    @coffee_shop_search_conditions << "時間制限：#{@time_limit}"
   end
   
 end

--- a/app/views/coffee_shops/show.html.erb
+++ b/app/views/coffee_shops/show.html.erb
@@ -84,6 +84,10 @@
 	  			<th>PC作業</th>
 	  			<td><%= @coffee_shop.pc_work %></td>
 	  		</tr>
+	  		<tr>
+	  			<th>時間制限</th>
+	  			<td><%= @coffee_shop.time_limit %></td>
+	  		</tr>
 	  	</tbody>
 	  </table>
 	  <div class="liker-container">

--- a/app/views/dashboard/coffee_shops/edit.html.erb
+++ b/app/views/dashboard/coffee_shops/edit.html.erb
@@ -97,6 +97,12 @@
   
   PC作業<br>
   <%= f.select :pc_work, PcWork.pluck(:name), { include_blank: '選択してください' } %>
+  
+  <br>
+  
+  時間制限<br>
+  <%= f.select :time_limit, TimeLimit.pluck(:name), { include_blank: '選択してください' } %>
+  
   <br>
   <%= f.submit "更新" %>
 <% end %>

--- a/app/views/dashboard/coffee_shops/new.html.erb
+++ b/app/views/dashboard/coffee_shops/new.html.erb
@@ -61,6 +61,7 @@
   </div>
   
   席数<%= f.number_field :shop_seats %>
+  <br>
   
   静かさ<br>
   <div class="check_box">
@@ -85,6 +86,11 @@
   
   PC作業<br>
   <%= f.select :pc_work, PcWork.pluck(:name), { include_blank: '選択してください' } %>
+  
+  <br>
+  
+  時間制限<br>
+  <%= f.select :time_limit, TimeLimit.pluck(:name), { include_blank: '選択してください' } %>
   
   <br>
   <%= f.submit "追加" %>

--- a/app/views/web/search.html.erb
+++ b/app/views/web/search.html.erb
@@ -157,6 +157,13 @@
       <%= f.select :pc_work, PcWork.pluck(:name), { include_blank: '未選択' }, :class => 'search-select' %>
     </div>
     
+    <br>
+    
+    <div class="search-container">
+      <div class="search-name">時間制限</div>
+      <%= f.select :time_limit, TimeLimit.pluck(:name), { include_blank: '未選択' }, :class => 'search-select' %>
+    </div>
+    
     <hr>
     <%= f.submit :search %>
   <% end %> 

--- a/db/migrate/20211212101418_create_time_limits.rb
+++ b/db/migrate/20211212101418_create_time_limits.rb
@@ -1,0 +1,9 @@
+class CreateTimeLimits < ActiveRecord::Migration[5.2]
+  def change
+    create_table :time_limits do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20211212101510_add_time_limit.rb
+++ b/db/migrate/20211212101510_add_time_limit.rb
@@ -1,0 +1,5 @@
+class AddTimeLimit < ActiveRecord::Migration[5.2]
+  def change
+    add_column :coffee_shops, :time_limit, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_12_090209) do
+ActiveRecord::Schema.define(version: 2021_12_12_101510) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -109,6 +109,7 @@ ActiveRecord::Schema.define(version: 2021_12_12_090209) do
     t.integer "shop_seats"
     t.string "shop_tell"
     t.string "pc_work"
+    t.string "time_limit"
   end
 
   create_table "day_of_weeks", force: :cascade do |t|
@@ -197,6 +198,12 @@ ActiveRecord::Schema.define(version: 2021_12_12_090209) do
   end
 
   create_table "shop_bgms", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "time_limits", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/test/fixtures/time_limits.yml
+++ b/test/fixtures/time_limits.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+
+two:
+  name: MyString

--- a/test/models/time_limit_test.rb
+++ b/test/models/time_limit_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class TimeLimitTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# 背景
- この機能が必要な理由
ユーザーが制限時間で店舗を検索できるようにするため
店舗情報に制限時間を表示するため

- どういう機能なのか
店舗情報に制限時間を登録する
制限時間で店舗を検索する

- なぜこのPR単位なのか
制限時間の処理でまとめるため

# やったこと
## コードベース
- 設計方針
制限時間のテーブルを作成する
登録する制限時間は限られているので、編集画面などは作成しないで、
直接データベースに登録して、追加する

- model
制限時間のテーブルを作成
検索用のテーブルに制限時間検索機能を追加

- controller
特に大きな変更はない

- view
- 検索項目と店舗詳細に制限時間を追加

# 画面レイアウト
- 店舗情報登録
![image](https://user-images.githubusercontent.com/87374457/145709535-aef81696-ed62-4fad-9c6f-564fd74d3e49.png)

- 店舗詳細
![image](https://user-images.githubusercontent.com/87374457/145709567-2d805df7-ea77-4f26-a4a6-45150cdd8f5e.png)

- 検索画面
![image](https://user-images.githubusercontent.com/87374457/145709563-8f832e1a-e703-4282-8eef-07c5ab9f1e68.png)

- 検索結果
![image](https://user-images.githubusercontent.com/87374457/145709567-2d805df7-ea77-4f26-a4a6-45150cdd8f5e.png)

# 検証内容
- [x] 店舗情報に時間制限の登録はできるか
- [x] 店舗情報の時間制限は変更できるか
- [x] 店舗情報詳細画面に時間制限は表示されているか
- [x] 検索条件に時間制限は表示されているか
- [x] 時間制限から検索ができるか