### PR TITLE
予算、値段を検索項目に追加

### DIFF
--- a/app/assets/stylesheets/coffee_shops.scss
+++ b/app/assets/stylesheets/coffee_shops.scss
@@ -88,7 +88,7 @@
 
 .shop-table th {
   text-align: left;
-  width: 130px;
+  width: 200px;
   background: #efefef;
   border: 0 solid #dbdbdb;
   border-width: 1px 0 0 1px;

--- a/app/assets/stylesheets/coffee_shops.scss
+++ b/app/assets/stylesheets/coffee_shops.scss
@@ -152,7 +152,7 @@
   font-size: 6rem;
   line-height: 1;
   position: absolute;
-  bottom: -1.3rem;
+  bottom: -1rem;
   left: 0;
   color: #CC935B;
 }
@@ -170,7 +170,7 @@
   font-size: 6rem;
   line-height: 1;
   position: absolute;
-  bottom: -1.3rem;
+  bottom: -1rem;
   left: 300px;
   color: #CC935B;
 }

--- a/app/controllers/coffee_shops_controller.rb
+++ b/app/controllers/coffee_shops_controller.rb
@@ -75,6 +75,11 @@ class CoffeeShopsController < ApplicationController
       hash[:free_pc] = params[:free_pc]
       hash[:parking_place] = params[:parking_place]
       hash[:payment_method_ids] = params[:payment_method_ids]
+      hash[:shop_badget] = params[:shop_badget]
+      hash[:coffee_price] = params[:coffee_price]
+      hash[:coffee_price_search_type] = params[:coffee_price_search_type]
+      hash[:latte_price] = params[:latte_price]
+      hash[:latte_price_search_type] = params[:latte_price_search_type]
       hash
     end
 end

--- a/app/controllers/dashboard/coffee_shops_controller.rb
+++ b/app/controllers/dashboard/coffee_shops_controller.rb
@@ -69,7 +69,7 @@ class Dashboard::CoffeeShopsController < ApplicationController
   end
   
   def coffee_shop_params
-    params.require(:coffee_shop).permit(:name, :shop_url, :address, :shop_tell, :access, :business_start_hour, :business_end_hour, :instagram_url, :instagram_spot_url, :municipalitie_id, :slack_time_start, :slack_time_end, :age_group, :shop_seats, :pc_work, :time_limit, :terrace_seat, :can_reserved, :comic, :magazine, :latte_art, :newspaper, :morning_menu, :parking_place, :free_water, :with_pet, :free_pc, 
+    params.require(:coffee_shop).permit(:name, :shop_url, :address, :shop_tell, :access, :business_start_hour, :business_end_hour, :instagram_url, :instagram_spot_url, :municipalitie_id, :slack_time_start, :slack_time_end, :age_group, :shop_seats, :pc_work, :time_limit, :terrace_seat, :can_reserved, :comic, :magazine, :latte_art, :newspaper, :morning_menu, :parking_place, :free_water, :with_pet, :free_pc, :shop_badget_upper, :shop_badget_lower, :coffee_price, :latte_price, 
     { :search_category_ids => [], :shop_atmosphere_ids => [], :coffee_bean_ids => [], :volume_in_shop_ids => [], :food_menu_ids => [], :shop_bgm_ids => [], :shop_scenery_ids => [], :payment_method_ids => [] }, images: [])
   end
   

--- a/app/models/coffee_shop.rb
+++ b/app/models/coffee_shop.rb
@@ -62,6 +62,9 @@ class CoffeeShop < ApplicationRecord
 	validate :business_start_hour_and_business_end_hour_must_be_set
 	validate :slack_time_start_and_slack_time_end_must_be_set
 	
+	# 予算
+	validate :shop_badget_lower_and_shop_badget_upper_must_be_set
+	
 	scope :search_for_name_and_tell, -> (keyword) {
 		where("name LIKE ?", "%#{keyword}%").
 		or(where(tell: keyword.to_i))
@@ -96,6 +99,16 @@ class CoffeeShop < ApplicationRecord
 			errors.add(:slack_time_start, "はすいている時間(終了)とペアで入力してください。")
 		elsif	slack_time_end.nil?
 			errors.add(:slack_time_end, "はすいている時間(開始)とペアで入力してください。")
+		end
+	end
+	
+	def shop_badget_lower_and_shop_badget_upper_must_be_set
+		return if shop_badget_lower.nil? && shop_badget_upper.nil?
+		
+		if shop_badget_lower.nil?
+			errors.add(:shop_badget_lower, "は予算(上限)とペアで入力してください。")
+		elsif	shop_badget_upper.nil?
+			errors.add(:shop_badget_upper, "は予算(下限)とペアで入力してください。")
 		end
 	end
 	

--- a/app/service/coffee_shop_search_service.rb
+++ b/app/service/coffee_shop_search_service.rb
@@ -34,6 +34,11 @@ class CoffeeShopSearchService
     @free_pc = hash[:free_pc]
     @parking_place = hash[:parking_place]
     @payment_method_ids = hash[:payment_method_ids]
+    @shop_badget = hash[:shop_badget]
+    @coffee_price = hash[:coffee_price]
+    @coffee_price_search_type = hash[:coffee_price_search_type]
+    @latte_price = hash[:latte_price]
+    @latte_price_search_type = hash[:latte_price_search_type]
   end
   
   def search
@@ -131,6 +136,15 @@ class CoffeeShopSearchService
     
     # 支払い方法
     search_by_payment_method if @payment_method_ids.present?
+    
+    # 予算
+    search_by_shop_badget if @shop_badget.present?
+    
+    # コーヒーの値段
+    search_by_coffee_price if @coffee_price.present?
+    
+    # カフェラテの値段
+    search_by_latte_price if @latte_price.present?
     
     @coffee_shops
   end
@@ -379,6 +393,45 @@ class CoffeeShopSearchService
   # 支払い方法
   def search_by_payment_method
     coffee_shop_ids = CoffeeShopPaymentMethod.where(payment_method_id: @payment_method_ids).pluck(:coffee_shop_id)
+    @coffee_shops = @coffee_shops.where(id: coffee_shop_ids)
+  end
+  
+  # 予算
+  def search_by_shop_badget
+    coffee_shop_ids = []
+    @coffee_shops.each do |coffee_shop|
+      if @shop_badget.to_i <= coffee_shop.shop_badget_upper.to_i && @shop_badget.to_i >= coffee_shop.shop_badget_lower.to_i
+        coffee_shop_ids << coffee_shop.id
+      end
+    end
+    @coffee_shops = @coffee_shops.where(id: coffee_shop_ids)
+  end
+  
+  # コーヒー1杯
+  def search_by_coffee_price
+    coffee_shop_ids = []
+    @coffee_shops.each do |coffee_shop|
+      next if coffee_shop.coffee_price.nil?
+      if @coffee_price_search_type.eql?("more_than") && @coffee_price.to_i <= coffee_shop.coffee_price.to_i
+        coffee_shop_ids << coffee_shop.id
+      elsif @coffee_price_search_type.eql?("less_than") && @coffee_price.to_i >= coffee_shop.coffee_price.to_i
+        coffee_shop_ids << coffee_shop.id
+      end
+    end
+    @coffee_shops = @coffee_shops.where(id: coffee_shop_ids)
+  end
+  
+  # カフェラテ1杯
+  def search_by_latte_price
+    coffee_shop_ids = []
+    @coffee_shops.each do |coffee_shop|
+      next if coffee_shop.latte_price.nil?
+      if @latte_price_search_type.eql?("more_than") && @latte_price.to_i <= coffee_shop.latte_price.to_i
+        coffee_shop_ids << coffee_shop.id
+      elsif @latte_price_search_type.eql?("less_than") && @latte_price.to_i >= coffee_shop.latte_price.to_i
+        coffee_shop_ids << coffee_shop.id
+      end
+    end
     @coffee_shops = @coffee_shops.where(id: coffee_shop_ids)
   end
   

--- a/app/service/coffee_shop_show_info_service.rb
+++ b/app/service/coffee_shop_show_info_service.rb
@@ -33,7 +33,10 @@ class CoffeeShopShowInfoService
     create_free_pc if @coffee_shop.free_pc.present?
     create_parking_place if @coffee_shop.parking_place.present?
     create_payment_method if @coffee_shop.payment_methods.present?
-    
+    create_shop_badget if @coffee_shop.shop_badget_lower.present?
+    create_coffee_price if @coffee_shop.coffee_price.present?
+    create_latte_price if @coffee_shop.latte_price.present?
+     
     @shop_info
   end
   
@@ -295,6 +298,33 @@ class CoffeeShopShowInfoService
     hash.class
     hash[:title] = '支払い方法'
     hash[:value] = @coffee_shop.payment_methods.pluck(:name).join(',')
+    @shop_info << hash
+  end
+  
+  # 予算
+  def create_shop_badget
+    hash = {}
+    hash.class
+    hash[:title] = '予算'
+    hash[:value] = '¥' + @coffee_shop.shop_badget_lower.to_s + '〜¥' + @coffee_shop.shop_badget_upper.to_s
+    @shop_info << hash
+  end
+  
+  # コーヒーの値段
+  def create_coffee_price
+    hash = {}
+    hash.class
+    hash[:title] = 'コーヒー(1杯)の値段'
+    hash[:value] = '¥' + @coffee_shop.coffee_price.to_s
+    @shop_info << hash
+  end
+  
+  # カフェラテの値段
+  def create_latte_price
+    hash = {}
+    hash.class
+    hash[:title] = 'カフェラテ(1杯)の値段'
+    hash[:value] = '¥' + @coffee_shop.latte_price.to_s
     @shop_info << hash
   end
   

--- a/app/service/create_coffee_shop_search_conditions_service.rb
+++ b/app/service/create_coffee_shop_search_conditions_service.rb
@@ -34,6 +34,11 @@ class CreateCoffeeShopSearchConditionsService
     @free_pc = hash[:free_pc]
     @parking_place = hash[:parking_place]
     @payment_method_ids = hash[:payment_method_ids]
+    @shop_badget = hash[:shop_badget]
+    @coffee_price = hash[:coffee_price]
+    @coffee_price_search_type = hash[:coffee_price_search_type]
+    @latte_price = hash[:latte_price]
+    @latte_price_search_type = hash[:latte_price_search_type]
   end
   
   def create
@@ -69,6 +74,9 @@ class CreateCoffeeShopSearchConditionsService
     create_free_pc if @free_pc.present?
     create_parking_place if @parking_place.present?
     create_payment_method if @payment_method_ids.present?
+    create_shop_badget if @shop_badget.present?
+    create_coffee_price if @coffee_price.present?
+    create_latte_price if @latte_price.present?
     
     @coffee_shop_search_conditions
   end
@@ -215,6 +223,20 @@ class CreateCoffeeShopSearchConditionsService
     payment_methods = PaymentMethod.where(id: @payment_method_ids)
     return_message = "風景：#{payment_methods.pluck(:name).join('or')}"
     @coffee_shop_search_conditions << return_message
+  end
+  
+  def create_shop_badget
+    @coffee_shop_search_conditions << "予算：#{@shop_badget}円"
+  end
+  
+  def create_coffee_price
+    @coffee_shop_search_conditions << "コーヒー1杯：#{@coffee_price}円以上" if @coffee_price_search_type.eql?("more_than") 
+    @coffee_shop_search_conditions << "コーヒー1杯：#{@coffee_price}円以下" if @coffee_price_search_type.eql?("less_than")
+  end
+  
+  def create_latte_price
+    @coffee_shop_search_conditions << "カフェラテ1杯：#{@latte_price}円以上" if @latte_price_search_type.eql?("more_than") 
+    @coffee_shop_search_conditions << "カフェラテ1杯：#{@latte_price}円以下" if @latte_price_search_type.eql?("less_than")
   end
   
 end

--- a/app/views/shared/dashboard/_shop_info.html.erb
+++ b/app/views/shared/dashboard/_shop_info.html.erb
@@ -117,6 +117,14 @@
       <%= payment_method.label { payment_method.check_box + payment_method.text } %>
     <% end %>
   </div>
+  <br>
+  予算(上限)：<%= f.number_field :shop_badget_upper %>円
+  <br>
+  予算(下限)；<%= f.number_field :shop_badget_lower %>円
+  <br>
+  コーヒー(1杯)：<%= f.number_field :coffee_price %>円
+  <br>
+  カフェラテ(1杯)：<%= f.number_field :latte_price %>円
   
   <hr>
   <% if metod.eql?('edit') %>

--- a/app/views/web/search.html.erb
+++ b/app/views/web/search.html.erb
@@ -16,8 +16,6 @@
       <%= f.text_field :name, :class => 'search-text' %>
     </div>
     
-    <br>
-    
     <div class="search-container">
       <div class="search-name">こだわり</div>
       <%= f.collection_check_boxes(:search_category_ids, SearchCategory.all, :id, :name, {include_hidden: false} ) do |search_category| %>
@@ -27,8 +25,6 @@
         </div>
       <% end %>
     </div>
-    
-    <br>
     
     <div class="search-container">
       <div class="search-name">お店の雰囲気</div>
@@ -40,8 +36,6 @@
       <% end %>
     </div>
     
-    <br>
-    
     <div class="search-container">
       <div class="search-name">レビュー点数</div>
       <%= f.number_field :review_score, :class => 'search-number' %>
@@ -52,6 +46,7 @@
         <%= f.label :review_score_search_type, "以下", {value: :less_than, style: "display: inline-block;"} %>
       </div>
     </div>
+    
     <div class="search-container">
       <div class="search-name">レビュー数</div>
       <%= f.number_field :review_count, :class => 'search-number' %>
@@ -102,8 +97,6 @@
       </div>
     </div>
     
-    <br>
-    
     <div class="search-container">
       <div class="search-name">コーヒー豆</div>
       <%= f.collection_check_boxes(:coffee_bean_ids, CoffeeBean.all, :id, :name, {include_hidden: false}) do |coffee_bean| %>
@@ -113,8 +106,6 @@
         </div>
       <% end %>
     </div>
-    
-    <br>
     
     <div class="search-container">
       <div class="search-name">お店の静かさ</div>
@@ -126,8 +117,6 @@
       <% end %>
     </div>
     
-    <br>
-    
     <div class="search-container">
       <div class="search-name">食べ物</div>
       <%= f.collection_check_boxes(:food_menu_ids, FoodMenu.all, :id, :name, {include_hidden: false}) do |food_menu| %>
@@ -137,8 +126,6 @@
         </div>
       <% end %>
     </div>
-    
-    <br>
     
     <div class="search-container">
       <div class="search-name">BGM</div>
@@ -150,21 +137,15 @@
       <% end %>
     </div>
     
-    <br>
-    
     <div class="search-container">
       <div class="search-name">PC作業</div>
       <%= f.select :pc_work, PcWork.pluck(:name), { include_blank: '未選択' }, :class => 'search-select' %>
     </div>
     
-    <br>
-    
     <div class="search-container">
       <div class="search-name">時間制限</div>
       <%= f.select :time_limit, TimeLimit.pluck(:name), { include_blank: '未選択' }, :class => 'search-select' %>
     </div>
-    
-    <br>
     
     <div class="search-container">
       <div class="search-name">風景</div>
@@ -175,7 +156,7 @@
         </div>
       <% end %>
     </div>
-    <br>
+    
     <div class="search-container">
       <div class="search-name">テラス席</div>
       <div class="search-radio">
@@ -205,7 +186,7 @@
         <%= f.label :comic, "なし", {value: "なし", style: "display: inline-block;"} %>
       </div>
     </div>
-    <br>
+    
     <div class="search-container">
       <div class="search-name">雑誌</div>
       <div class="search-radio">
@@ -235,7 +216,7 @@
         <%= f.label :newspaper, "なし", {value: "なし", style: "display: inline-block;"} %>
       </div>
     </div>
-    <br>
+    
     <div class="search-container">
       <div class="search-name">モーニング</div>
       <div class="search-radio">
@@ -265,7 +246,7 @@
         <%= f.label :with_pet, "不可", {value: "不可", style: "display: inline-block;"} %>
       </div>
     </div>
-    <br>
+    
     <div class="search-container">
       <div class="search-name">共有PC</div>
       <div class="search-radio">
@@ -285,7 +266,7 @@
         <%= f.label :parking_place, "なし", {value: "なし", style: "display: inline-block;"} %>
       </div>
     </div>
-    <br>
+    
     <div class="search-container">
       <div class="search-name">支払い方法</div>
       <%= f.collection_check_boxes(:payment_method_ids, PaymentMethod.all, :id, :name, {include_hidden: false}) do |payment_method| %>
@@ -294,6 +275,33 @@
           <%= payment_method.label %>
         </div>
       <% end %>
+    </div>
+    
+    <div class="search-container">
+      <div class="search-name">予算</div>
+      <%= f.number_field :shop_badget, :class => 'search-number' %>円
+    </div>
+    
+    <div class="search-container">
+      <div class="search-name">コーヒー1杯</div>
+      <%= f.number_field :coffee_price, :class => 'search-number' %>
+      <div class="search-radio">
+        <%= f.radio_button :coffee_price_search_type, :more_than, {:checked => true} %>
+        <%= f.label :coffee_price_search_type, "以上", {value: :more_than, style: "display: inline-block;"} %>
+        <%= f.radio_button :coffee_price_search_type, :less_than %>
+        <%= f.label :coffee_price_search_type, "以下", {value: :less_than, style: "display: inline-block;"} %>
+      </div>
+    </div>
+    
+    <div class="search-container">
+      <div class="search-name">カフェラテ1杯</div>
+      <%= f.number_field :latte_price, :class => 'search-number' %>
+      <div class="search-radio">
+        <%= f.radio_button :latte_price_search_type, :more_than, {:checked => true} %>
+        <%= f.label :latte_price_search_type, "以上", {value: :more_than, style: "display: inline-block;"} %>
+        <%= f.radio_button :latte_price_search_type, :less_than %>
+        <%= f.label :latte_price_search_type, "以下", {value: :less_than, style: "display: inline-block;"} %>
+      </div>
     </div>
     
     <hr>

--- a/config/locales/models/ja.yml
+++ b/config/locales/models/ja.yml
@@ -21,6 +21,8 @@ ja:
         slack_time_start: すいている時間(開始) 
         slack_time_end: すいている時間(終了)
         shop_tell: 電話番号
+        shop_badget_lower: 予算(下限) 
+        shop_badget_upper: 予算(上限)
         
       user:
         name: ユーザー名

--- a/db/migrate/20211223095645_add_badget.rb
+++ b/db/migrate/20211223095645_add_badget.rb
@@ -1,0 +1,8 @@
+class AddBadget < ActiveRecord::Migration[5.2]
+  def change
+    add_column :coffee_shops, :shop_badget_upper, :integer
+    add_column :coffee_shops, :shop_badget_lower, :integer
+    add_column :coffee_shops, :coffee_price, :integer
+    add_column :coffee_shops, :latte_price, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_21_110549) do
+ActiveRecord::Schema.define(version: 2021_12_23_095645) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -135,6 +135,10 @@ ActiveRecord::Schema.define(version: 2021_12_21_110549) do
     t.string "free_water"
     t.string "with_pet"
     t.string "free_pc"
+    t.integer "shop_badget_upper"
+    t.integer "shop_badget_lower"
+    t.integer "coffee_price"
+    t.integer "latte_price"
   end
 
   create_table "day_of_weeks", force: :cascade do |t|


### PR DESCRIPTION
# 背景
- この機能が必要な理由
予算、コーヒーの値段、カフェラテの値段から店舗を検索するため
店舗情報に予算、コーヒーの値段、カフェラテの値段を表示するため

- どういう機能なのか
店舗情報に予算、コーヒーの値段、カフェラテの値段を登録できる
予算、コーヒーの値段、カフェラテの値段から店舗を検索できる

- なぜこのPR単位なのか
予算、コーヒーの値段、カフェラテの値段でまとめるため

# やったこと
## コードベース
- 設計方針
店舗がもっているそれぞれの情報は単一なので、コーヒーショップテーブルにカラムを追加する
予算は上限と下限を作成する

- model
コーヒーショップテーブルに追加

- controller
特に変わったとこはなし

- view
ちょっっと検索項目選択画面を変更

# 画面レイアウト
- 店舗情報入力
![image](https://user-images.githubusercontent.com/87374457/147379344-36c2bbff-1393-409a-a266-c5156aa6072f.png)

- 検索
![image](https://user-images.githubusercontent.com/87374457/147379357-f8405637-004a-4eb8-a62c-2da1f4f5db18.png)

- 店舗詳細
![image](https://user-images.githubusercontent.com/87374457/147379373-a7cb0b80-02ce-49d6-8c3f-bda6e9d76af3.png)

# 検証内容
- [x] 各項目は店舗情報に登録できるか
- [x] 各項目は変更ができるか
- [x] 各項目から店舗の検索ができるか
- [x] 店舗詳細に各項目が表示されているか