### PR TITLE
椅子の種類を検索項目に追加

### DIFF
--- a/app/assets/stylesheets/search.scss
+++ b/app/assets/stylesheets/search.scss
@@ -2,7 +2,7 @@
   width: fit-content;
   position: relative;
   margin: 0.5em;
-  padding: 0.5em 1em;
+  padding: 0em 1em;
   border: solid 3px #CC935B;
   border-radius: 8px;
   display: inline-block;
@@ -134,6 +134,13 @@
   position: relative;
 	border-color: white;
   border: 0px;
+}
+
+.search-number::-webkit-inner-spin-button,
+.search-number::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+  -moz-appearance:textfield;
 }
 
 // 時間入力

--- a/app/assets/stylesheets/web.scss
+++ b/app/assets/stylesheets/web.scss
@@ -193,3 +193,17 @@
   width: fit-content;
   display: inline-block;
 }
+
+.cp_iptxt {
+	position: relative;
+	border-color: #CC935B;
+}
+.cp_iptxt input[type='text']:focus {
+	width: 100%;
+	padding: 0.3em;
+	transition: 0.3s;
+	letter-spacing: 1px;
+	border-bottom: 2px solid #800000;
+	background: transparent;
+	box-shadow: 0 0 7px #800000;
+}

--- a/app/assets/stylesheets/web.scss
+++ b/app/assets/stylesheets/web.scss
@@ -236,4 +236,5 @@
   background-color: #CC935B;
   border: none;
   height: 2em;
+  border-radius: 0.5em;
 }

--- a/app/assets/stylesheets/web.scss
+++ b/app/assets/stylesheets/web.scss
@@ -197,6 +197,7 @@
 .cp_iptxt {
 	position: relative;
 	border-color: #CC935B;
+	height: 2em;
 }
 .cp_iptxt input[type='text']:focus {
 	width: 100%;
@@ -206,4 +207,33 @@
 	border-bottom: 2px solid #800000;
 	background: transparent;
 	box-shadow: 0 0 7px #800000;
+}
+
+.cp_ipnum {
+	position: relative;
+	border-color: #CC935B;
+	height: 2em;
+}
+.cp_ipnum input[type='number']:focus {
+	width: 100%;
+	padding: 0.3em;
+	transition: 0.3s;
+	letter-spacing: 1px;
+	border-bottom: 2px solid #800000;
+	background: transparent;
+	box-shadow: 0 0 7px #800000;
+}
+
+.cp_ipnum::-webkit-inner-spin-button,
+.cp_ipnum::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+  -moz-appearance:textfield;
+}
+
+.btn-search {
+  color: #ffffff;
+  background-color: #CC935B;
+  border: none;
+  height: 2em;
 }

--- a/app/controllers/coffee_shops_controller.rb
+++ b/app/controllers/coffee_shops_controller.rb
@@ -80,6 +80,7 @@ class CoffeeShopsController < ApplicationController
       hash[:coffee_price_search_type] = params[:coffee_price_search_type]
       hash[:latte_price] = params[:latte_price]
       hash[:latte_price_search_type] = params[:latte_price_search_type]
+      hash[:chair_type_ids] = params[:chair_type_ids]
       hash
     end
 end

--- a/app/controllers/dashboard/chair_types_controller.rb
+++ b/app/controllers/dashboard/chair_types_controller.rb
@@ -1,0 +1,59 @@
+class Dashboard::ChairTypesController < ApplicationController
+  before_action :set_chair_type, only: %w[show edit update destroy]
+  before_action :check_user_authority, except: :index
+  layout "dashboard/dashboard"
+  
+  def index
+    @chair_types = ChairType.all
+    @chair_type = ChairType.new
+  end
+  
+  def show
+  end
+  
+  def create
+    @chair_type = ChairType.new(chair_type_params)
+    if @chair_type.save
+      redirect_to dashboard_chair_types_path, notice: '登録が完了しました'
+    else
+      flash[:alert] = @chair_type.errors.full_messages
+      redirect_back(fallback_location: dashboard_chair_types_path)
+    end
+  end
+  
+  def edit
+  end
+  
+  def update
+    if @chair_type.update(chair_type_params)
+      redirect_to dashboard_chair_types_path, notice: '変更が完了しました。'
+    else
+      flash[:alert] = @chair_type.errors.full_messages
+      redirect_back(fallback_location: dashboard_chair_types_path)
+    end
+  end
+  
+  def destroy
+    @chair_type.destroy
+    redirect_to dashboard_chair_types_path
+  end
+  
+  private
+  
+  def set_chair_type
+    @chair_type = ChairType.find(params[:id])
+  end
+  
+  def chair_type_params
+    params.require(:chair_type).permit(:name)
+  end
+  
+  def check_user_authority
+    @user = current_user
+    if @user.authority.eql?("2")
+      flash[:alert] = "アクセス権限がないです。"
+      redirect_to dashboard_path
+    end
+  end
+  
+end

--- a/app/controllers/dashboard/coffee_shops_controller.rb
+++ b/app/controllers/dashboard/coffee_shops_controller.rb
@@ -70,7 +70,7 @@ class Dashboard::CoffeeShopsController < ApplicationController
   
   def coffee_shop_params
     params.require(:coffee_shop).permit(:name, :shop_url, :address, :shop_tell, :access, :business_start_hour, :business_end_hour, :instagram_url, :instagram_spot_url, :municipalitie_id, :slack_time_start, :slack_time_end, :age_group, :shop_seats, :pc_work, :time_limit, :terrace_seat, :can_reserved, :comic, :magazine, :latte_art, :newspaper, :morning_menu, :parking_place, :free_water, :with_pet, :free_pc, :shop_badget_upper, :shop_badget_lower, :coffee_price, :latte_price, 
-    { :search_category_ids => [], :shop_atmosphere_ids => [], :coffee_bean_ids => [], :volume_in_shop_ids => [], :food_menu_ids => [], :shop_bgm_ids => [], :shop_scenery_ids => [], :payment_method_ids => [] }, images: [])
+    { :search_category_ids => [], :shop_atmosphere_ids => [], :coffee_bean_ids => [], :volume_in_shop_ids => [], :food_menu_ids => [], :shop_bgm_ids => [], :shop_scenery_ids => [], :payment_method_ids => [], :chair_type_ids => [] }, images: [])
   end
   
   def check_user_authority

--- a/app/models/chair_type.rb
+++ b/app/models/chair_type.rb
@@ -1,0 +1,13 @@
+class ChairType < ApplicationRecord
+  has_many :coffee_shop_chair_types, dependent: :destroy
+  has_many :coffee_shops, :through => :coffee_shop_chair_types
+  
+  #空白禁止
+  validates :name, presence: true
+  
+  # 重複禁止
+	validates :name, uniqueness: true
+	
+	# 文字数
+	validates :name, length: { maximum: 15}
+end

--- a/app/models/coffee_shop.rb
+++ b/app/models/coffee_shop.rb
@@ -25,6 +25,9 @@ class CoffeeShop < ApplicationRecord
 	has_many :coffee_shop_payment_methods, dependent: :destroy
 	has_many :payment_methods, :through => :coffee_shop_payment_methods
 	
+	has_many :coffee_shop_chiar_types, dependent: :destroy
+	has_many :chair_types, :through => :coffee_shop_chiar_types
+	
 	accepts_nested_attributes_for :coffee_shop_search_categories, allow_destroy: true
 	accepts_nested_attributes_for :coffee_shop_shop_atmospheres, allow_destroy: true
 	accepts_nested_attributes_for :coffee_shop_coffee_beans, allow_destroy: true
@@ -33,6 +36,7 @@ class CoffeeShop < ApplicationRecord
 	accepts_nested_attributes_for :coffee_shop_shop_bgms, allow_destroy: true
 	accepts_nested_attributes_for :coffee_shop_shop_sceneries, allow_destroy: true
 	accepts_nested_attributes_for :coffee_shop_payment_methods, allow_destroy: true
+	accepts_nested_attributes_for :coffee_shop_chiar_types, allow_destroy: true
 	acts_as_likeable
 	has_many_attached :images
 	

--- a/app/models/coffee_shop.rb
+++ b/app/models/coffee_shop.rb
@@ -25,8 +25,8 @@ class CoffeeShop < ApplicationRecord
 	has_many :coffee_shop_payment_methods, dependent: :destroy
 	has_many :payment_methods, :through => :coffee_shop_payment_methods
 	
-	has_many :coffee_shop_chiar_types, dependent: :destroy
-	has_many :chair_types, :through => :coffee_shop_chiar_types
+	has_many :coffee_shop_chair_types, dependent: :destroy
+	has_many :chair_types, :through => :coffee_shop_chair_types
 	
 	accepts_nested_attributes_for :coffee_shop_search_categories, allow_destroy: true
 	accepts_nested_attributes_for :coffee_shop_shop_atmospheres, allow_destroy: true
@@ -36,7 +36,7 @@ class CoffeeShop < ApplicationRecord
 	accepts_nested_attributes_for :coffee_shop_shop_bgms, allow_destroy: true
 	accepts_nested_attributes_for :coffee_shop_shop_sceneries, allow_destroy: true
 	accepts_nested_attributes_for :coffee_shop_payment_methods, allow_destroy: true
-	accepts_nested_attributes_for :coffee_shop_chiar_types, allow_destroy: true
+	accepts_nested_attributes_for :coffee_shop_chair_types, allow_destroy: true
 	acts_as_likeable
 	has_many_attached :images
 	

--- a/app/models/coffee_shop_chair_type.rb
+++ b/app/models/coffee_shop_chair_type.rb
@@ -1,0 +1,4 @@
+class CoffeeShopChairType < ApplicationRecord
+  belongs_to :coffee_shop
+  belongs_to :chair_type
+end

--- a/app/service/coffee_shop_search_service.rb
+++ b/app/service/coffee_shop_search_service.rb
@@ -39,6 +39,7 @@ class CoffeeShopSearchService
     @coffee_price_search_type = hash[:coffee_price_search_type]
     @latte_price = hash[:latte_price]
     @latte_price_search_type = hash[:latte_price_search_type]
+    @chair_type_ids = hash[:chair_type_ids]
   end
   
   def search
@@ -145,6 +146,9 @@ class CoffeeShopSearchService
     
     # カフェラテの値段
     search_by_latte_price if @latte_price.present?
+    
+    # 椅子の種類
+    search_by_chair_type if @chair_type_ids.present?
     
     @coffee_shops
   end
@@ -432,6 +436,12 @@ class CoffeeShopSearchService
         coffee_shop_ids << coffee_shop.id
       end
     end
+    @coffee_shops = @coffee_shops.where(id: coffee_shop_ids)
+  end
+  
+  # 椅子の種類
+  def search_by_chair_type
+    coffee_shop_ids = CoffeeShopChairType.where(chair_type_id: @chair_type_ids).pluck(:coffee_shop_id)
     @coffee_shops = @coffee_shops.where(id: coffee_shop_ids)
   end
   

--- a/app/service/coffee_shop_show_info_service.rb
+++ b/app/service/coffee_shop_show_info_service.rb
@@ -36,6 +36,7 @@ class CoffeeShopShowInfoService
     create_shop_badget if @coffee_shop.shop_badget_lower.present?
     create_coffee_price if @coffee_shop.coffee_price.present?
     create_latte_price if @coffee_shop.latte_price.present?
+    create_chair_type if @coffee_shop.chair_types.present?
      
     @shop_info
   end
@@ -325,6 +326,15 @@ class CoffeeShopShowInfoService
     hash.class
     hash[:title] = 'カフェラテ(1杯)の値段'
     hash[:value] = '¥' + @coffee_shop.latte_price.to_s
+    @shop_info << hash
+  end
+  
+  # 椅子の種類
+  def create_chair_type
+    hash = {}
+    hash.class
+    hash[:title] = '椅子の種類'
+    hash[:value] = @coffee_shop.chair_types.pluck(:name).join(',')
     @shop_info << hash
   end
   

--- a/app/service/create_coffee_shop_search_conditions_service.rb
+++ b/app/service/create_coffee_shop_search_conditions_service.rb
@@ -39,6 +39,7 @@ class CreateCoffeeShopSearchConditionsService
     @coffee_price_search_type = hash[:coffee_price_search_type]
     @latte_price = hash[:latte_price]
     @latte_price_search_type = hash[:latte_price_search_type]
+    @chair_type_ids = hash[:chair_type_ids]
   end
   
   def create
@@ -77,6 +78,7 @@ class CreateCoffeeShopSearchConditionsService
     create_shop_badget if @shop_badget.present?
     create_coffee_price if @coffee_price.present?
     create_latte_price if @latte_price.present?
+    create_chair_type if @chair_type_ids.present?
     
     @coffee_shop_search_conditions
   end
@@ -237,6 +239,12 @@ class CreateCoffeeShopSearchConditionsService
   def create_latte_price
     @coffee_shop_search_conditions << "カフェラテ1杯：#{@latte_price}円以上" if @latte_price_search_type.eql?("more_than") 
     @coffee_shop_search_conditions << "カフェラテ1杯：#{@latte_price}円以下" if @latte_price_search_type.eql?("less_than")
+  end
+  
+  def create_chair_type
+    chair_types = ChairType.where(id: @chair_type_ids)
+    return_message = "椅子の種類：#{chair_types.pluck(:name).join('or')}"
+    @coffee_shop_search_conditions << return_message
   end
   
 end

--- a/app/views/coffee_shops/show.html.erb
+++ b/app/views/coffee_shops/show.html.erb
@@ -98,7 +98,6 @@
 				<% end %>
 			</div>
 		<% end %>
-		
 	<%= link_to "戻る", :back %>
 
 	</div>

--- a/app/views/dashboard/chair_types/edit.html.erb
+++ b/app/views/dashboard/chair_types/edit.html.erb
@@ -1,0 +1,9 @@
+<h1>椅子の種類編集</h1>
+
+<%= form_with model: @chair_type, url: dashboard_chair_type_path(@chair_type), local: true do |f| %>
+  <%= f.label :name, "椅子の種類" %>
+  <%= f.text_field :name %>
+  
+  <%= f.submit "更新" %>
+<% end %>
+<%= link_to "椅子の種類一覧に戻る", dashboard_chair_types_path %>

--- a/app/views/dashboard/chair_types/index.html.erb
+++ b/app/views/dashboard/chair_types/index.html.erb
@@ -1,0 +1,3 @@
+<%= render partial: 'shared/dashboard/search_items_index', locals: 
+{ item_name: '椅子の種類', search_item: @chair_type, search_items_path: dashboard_chair_types_path,
+search_items: @chair_types, items: 'chair_types', itemp: 'chair_type' } %>

--- a/app/views/layouts/dashboard/_sidebar.html.erb
+++ b/app/views/layouts/dashboard/_sidebar.html.erb
@@ -28,4 +28,6 @@
     <%= link_to "風景一覧", dashboard_shop_sceneries_path %>
   <br>
     <%= link_to "支払い方法一覧", dashboard_payment_methods_path %>
+  <br>
+    <%= link_to "椅子の種類一覧", dashboard_chair_types_path %>
 </div>

--- a/app/views/shared/dashboard/_shop_info.html.erb
+++ b/app/views/shared/dashboard/_shop_info.html.erb
@@ -125,6 +125,13 @@
   コーヒー(1杯)：<%= f.number_field :coffee_price %>円
   <br>
   カフェラテ(1杯)：<%= f.number_field :latte_price %>円
+  <br>
+  椅子の種類<br>
+  <div class="check_box">
+    <%= f.collection_check_boxes(:chair_type_ids, ChairType.all, :id, :name) do |chair_type| %>
+      <%= chair_type.label { chair_type.check_box + chair_type.text } %>
+    <% end %>
+  </div>
   
   <hr>
   <% if metod.eql?('edit') %>

--- a/app/views/users/favorite.html.erb
+++ b/app/views/users/favorite.html.erb
@@ -19,7 +19,7 @@
           <%= render partial: 'shared/show_image_first', locals: { target: favorite_coffee_shop, image_size: "100x100" } %>
         </td>
         <td><%= link_to favorite_coffee_shop.name, coffee_shop_path(favorite_coffee_shop) %></td>
-        <td><%= favorite_coffee_shop.tell %></td>
+        <td><%= favorite_coffee_shop.shop_tell %></td>
         <td><%= favorite_coffee_shop.address %></td>
         <td><%= link_to "解除", favorite_coffee_shop_path(favorite_coffee_shop,target_action: "favorite") %></td>
       </tr>

--- a/app/views/web/index.html.erb
+++ b/app/views/web/index.html.erb
@@ -48,7 +48,9 @@
       <div class="search-text">
         shop name
         <br>
-        <%= f.text_field :name %>
+        <div class="cp_iptxt">
+          <%= f.text_field :name, :class => 'cp_iptxt' %>
+        </div>
       </div>
       <div class="search-text">
         tell

--- a/app/views/web/index.html.erb
+++ b/app/views/web/index.html.erb
@@ -55,10 +55,12 @@
       <div class="search-text">
         tell
         <br>
-        <%= f.number_field :shop_tell %>
+        <div class="cp_ipnum">
+          <%= f.number_field :shop_tell, :class => 'cp_ipnum' %>
+        </div>
       </div>
       <div class="search-btn">
-        <%= f.submit :search %>
+        <%= f.submit :search, :class => 'btn-search' %>
       </div>
     <% end %> 
   </div>
@@ -66,7 +68,7 @@
   <br>
   
   <div class="search_by_area2">
-    自分にぴったりなカフェを探す
+    様々な検索条件から自分にぴったりなカフェを探す
     <br>
     <% Prefecture.all.each do |prefecture| %>
       <%= link_to search_path(prefecture_id: prefecture.id) , class: "btn btn-prefecture" do %>

--- a/app/views/web/search.html.erb
+++ b/app/views/web/search.html.erb
@@ -304,6 +304,16 @@
       </div>
     </div>
     
+    <div class="search-container">
+      <div class="search-name">椅子の種類</div>
+      <%= f.collection_check_boxes(:chair_type_ids, ChairType.all, :id, :name, {include_hidden: false}) do |chair_type| %>
+        <div class="search-checkbox">
+          <%= chair_type.check_box %>
+          <%= chair_type.label %>
+        </div>
+      <% end %>
+    </div>
+    
     <hr>
     <%= f.submit :search %>
   <% end %> 

--- a/app/views/web/search.html.erb
+++ b/app/views/web/search.html.erb
@@ -315,6 +315,6 @@
     </div>
     
     <hr>
-    <%= f.submit :search %>
+    <%= f.submit :search, :class => 'btn-search' %>
   <% end %> 
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,7 @@ Rails.application.routes.draw do
     resources :shop_bgms, except: [:new]
     resources :shop_sceneries, except: [:new]
     resources :payment_methods, except: [:new]
+    resources :chair_types, except: [:new]
   end
   
   devise_for :users, :controllers => {

--- a/db/migrate/20211225074956_create_chair_types.rb
+++ b/db/migrate/20211225074956_create_chair_types.rb
@@ -1,0 +1,9 @@
+class CreateChairTypes < ActiveRecord::Migration[5.2]
+  def change
+    create_table :chair_types do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20211225075048_create_coffee_shop_chair_types.rb
+++ b/db/migrate/20211225075048_create_coffee_shop_chair_types.rb
@@ -1,0 +1,10 @@
+class CreateCoffeeShopChairTypes < ActiveRecord::Migration[5.2]
+  def change
+    create_table :coffee_shop_chair_types do |t|
+      t.integer :coffee_shop_id
+      t.integer :chair_type_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_23_095645) do
+ActiveRecord::Schema.define(version: 2021_12_25_075048) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -39,8 +39,21 @@ ActiveRecord::Schema.define(version: 2021_12_23_095645) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "chair_types", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "coffee_beans", force: :cascade do |t|
     t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "coffee_shop_chair_types", force: :cascade do |t|
+    t.integer "coffee_shop_id"
+    t.integer "chair_type_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/test/fixtures/chair_types.yml
+++ b/test/fixtures/chair_types.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+
+two:
+  name: MyString

--- a/test/fixtures/coffee_shop_chair_types.yml
+++ b/test/fixtures/coffee_shop_chair_types.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  coffee_shop_id: 1
+  chair_type_id: 1
+
+two:
+  coffee_shop_id: 1
+  chair_type_id: 1

--- a/test/models/chair_type_test.rb
+++ b/test/models/chair_type_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class ChairTypeTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/coffee_shop_chair_type_test.rb
+++ b/test/models/coffee_shop_chair_type_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class CoffeeShopChairTypeTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# 背景
- この機能が必要な理由
椅子の種類から店舗の検索ができるように
店舗情報に椅子の種類を表示できるように

- どういう機能なのか
店舗情報に椅子の種類を表示する
椅子の情報から店舗情報を検索する

- なぜこのPR単位なのか
椅子の種類でまとめるため

# やったこと
## コードベース
- 設計方針
中間テーブルを用いて、椅子の種類のテーブルとコーヒーショップテーブルを紐づける
管理画面から椅子の種類は登録や編集ができるようにする

- model
椅子の種類と中間テーブルを作成

- controller
椅子の種類を編集するためのコントローラーを作成

- view
椅子の種類を登録、編集するための画面を追加

# 画面レイアウト
- 椅子の種類登録画面
![image](https://user-images.githubusercontent.com/87374457/147807390-757bcdc1-3e3a-4de8-8b5f-8e73da465000.png)

- 検索画面
![image](https://user-images.githubusercontent.com/87374457/147807414-16ba6cf7-d708-4cb2-9185-2a6a86846e0d.png)

- 店舗詳細画面
![image](https://user-images.githubusercontent.com/87374457/147807426-62198253-2244-452a-a8c5-ca85ade8992f.png)

# 検証内容
- [x] 椅子の種類の登録ができるか
- [x] 椅子の種類の編集ができるか
- [x] 椅子の種類の削除ができるか
- [x] 椅子の種類を店舗情報に登録できるか
- [x] 店舗情報に登録された椅子の種類は変更できるか
- [x] 椅子の種類から店舗の検索ができるか
- [x] 店舗情報に椅子の種類は表示されているか