### PR TITLE
コンセントとWIfIと喫煙可能かを検索項目に追加

### DIFF
--- a/app/controllers/coffee_shops_controller.rb
+++ b/app/controllers/coffee_shops_controller.rb
@@ -81,6 +81,7 @@ class CoffeeShopsController < ApplicationController
       hash[:latte_price] = params[:latte_price]
       hash[:latte_price_search_type] = params[:latte_price_search_type]
       hash[:chair_type_ids] = params[:chair_type_ids]
+      hash[:outlet] = params[:outlet]
       hash
     end
 end

--- a/app/controllers/coffee_shops_controller.rb
+++ b/app/controllers/coffee_shops_controller.rb
@@ -82,6 +82,8 @@ class CoffeeShopsController < ApplicationController
       hash[:latte_price_search_type] = params[:latte_price_search_type]
       hash[:chair_type_ids] = params[:chair_type_ids]
       hash[:outlet] = params[:outlet]
+      hash[:wifi] = params[:wifi]
+      hash[:smoking] = params[:smoking]
       hash
     end
 end

--- a/app/controllers/dashboard/coffee_shops_controller.rb
+++ b/app/controllers/dashboard/coffee_shops_controller.rb
@@ -69,7 +69,7 @@ class Dashboard::CoffeeShopsController < ApplicationController
   end
   
   def coffee_shop_params
-    params.require(:coffee_shop).permit(:name, :shop_url, :address, :shop_tell, :access, :business_start_hour, :business_end_hour, :instagram_url, :instagram_spot_url, :municipalitie_id, :slack_time_start, :slack_time_end, :age_group, :shop_seats, :pc_work, :time_limit, :terrace_seat, :can_reserved, :comic, :magazine, :latte_art, :newspaper, :morning_menu, :parking_place, :free_water, :with_pet, :free_pc, :shop_badget_upper, :shop_badget_lower, :coffee_price, :latte_price, 
+    params.require(:coffee_shop).permit(:name, :shop_url, :address, :shop_tell, :access, :business_start_hour, :business_end_hour, :instagram_url, :instagram_spot_url, :municipalitie_id, :slack_time_start, :slack_time_end, :age_group, :shop_seats, :pc_work, :time_limit, :terrace_seat, :can_reserved, :comic, :magazine, :latte_art, :newspaper, :morning_menu, :parking_place, :free_water, :with_pet, :free_pc, :shop_badget_upper, :shop_badget_lower, :coffee_price, :latte_price, :outlet, :existence_wifi, :can_smoking, 
     { :search_category_ids => [], :shop_atmosphere_ids => [], :coffee_bean_ids => [], :volume_in_shop_ids => [], :food_menu_ids => [], :shop_bgm_ids => [], :shop_scenery_ids => [], :payment_method_ids => [], :chair_type_ids => [] }, images: [])
   end
   

--- a/app/controllers/dashboard/coffee_shops_controller.rb
+++ b/app/controllers/dashboard/coffee_shops_controller.rb
@@ -69,7 +69,7 @@ class Dashboard::CoffeeShopsController < ApplicationController
   end
   
   def coffee_shop_params
-    params.require(:coffee_shop).permit(:name, :shop_url, :address, :shop_tell, :access, :business_start_hour, :business_end_hour, :instagram_url, :instagram_spot_url, :municipalitie_id, :slack_time_start, :slack_time_end, :age_group, :shop_seats, :pc_work, :time_limit, :terrace_seat, :can_reserved, :comic, :magazine, :latte_art, :newspaper, :morning_menu, :parking_place, :free_water, :with_pet, :free_pc, :shop_badget_upper, :shop_badget_lower, :coffee_price, :latte_price, :outlet, :existence_wifi, :can_smoking, 
+    params.require(:coffee_shop).permit(:name, :shop_url, :address, :shop_tell, :access, :business_start_hour, :business_end_hour, :instagram_url, :instagram_spot_url, :municipalitie_id, :slack_time_start, :slack_time_end, :age_group, :shop_seats, :pc_work, :time_limit, :terrace_seat, :can_reserved, :comic, :magazine, :latte_art, :newspaper, :morning_menu, :parking_place, :free_water, :with_pet, :free_pc, :shop_badget_upper, :shop_badget_lower, :coffee_price, :latte_price, :outlet, :wifi, :smoking, 
     { :search_category_ids => [], :shop_atmosphere_ids => [], :coffee_bean_ids => [], :volume_in_shop_ids => [], :food_menu_ids => [], :shop_bgm_ids => [], :shop_scenery_ids => [], :payment_method_ids => [], :chair_type_ids => [] }, images: [])
   end
   

--- a/app/helpers/dashboard/coffee_shops_helper.rb
+++ b/app/helpers/dashboard/coffee_shops_helper.rb
@@ -1,2 +1,3 @@
 module Dashboard::CoffeeShopsHelper
+
 end

--- a/app/models/coffee_shop.rb
+++ b/app/models/coffee_shop.rb
@@ -69,6 +69,9 @@ class CoffeeShop < ApplicationRecord
 	# 予算
 	validate :shop_badget_lower_and_shop_badget_upper_must_be_set
 	
+	# enum
+	enum outlet: { none_seat: 0, all_seat: 1, part_seat: 2 }
+	
 	scope :search_for_name_and_tell, -> (keyword) {
 		where("name LIKE ?", "%#{keyword}%").
 		or(where(tell: keyword.to_i))

--- a/app/models/coffee_shop.rb
+++ b/app/models/coffee_shop.rb
@@ -71,6 +71,8 @@ class CoffeeShop < ApplicationRecord
 	
 	# enum
 	enum outlet: { none_seat: 0, all_seat: 1, part_seat: 2 }
+	enum wifi: { available: 0, not_available: 1 }
+	enum smoking: { smoking: 0, no_smoking: 1, separate_smoke: 2}
 	
 	scope :search_for_name_and_tell, -> (keyword) {
 		where("name LIKE ?", "%#{keyword}%").

--- a/app/service/coffee_shop_search_service.rb
+++ b/app/service/coffee_shop_search_service.rb
@@ -40,6 +40,7 @@ class CoffeeShopSearchService
     @latte_price = hash[:latte_price]
     @latte_price_search_type = hash[:latte_price_search_type]
     @chair_type_ids = hash[:chair_type_ids]
+    @outlet = hash[:outlet]
   end
   
   def search
@@ -149,6 +150,9 @@ class CoffeeShopSearchService
     
     # 椅子の種類
     search_by_chair_type if @chair_type_ids.present?
+    
+    # コンセント
+    srarch_by_outlet if @outlet.present?
     
     @coffee_shops
   end
@@ -443,6 +447,11 @@ class CoffeeShopSearchService
   def search_by_chair_type
     coffee_shop_ids = CoffeeShopChairType.where(chair_type_id: @chair_type_ids).pluck(:coffee_shop_id)
     @coffee_shops = @coffee_shops.where(id: coffee_shop_ids)
+  end
+  
+  # コンセント
+  def srarch_by_outlet
+    @coffee_shops = @coffee_shops.where(outlet: @outlet)
   end
   
 end

--- a/app/service/coffee_shop_search_service.rb
+++ b/app/service/coffee_shop_search_service.rb
@@ -41,6 +41,8 @@ class CoffeeShopSearchService
     @latte_price_search_type = hash[:latte_price_search_type]
     @chair_type_ids = hash[:chair_type_ids]
     @outlet = hash[:outlet]
+    @wifi = hash[:wifi]
+    @smoking = hash[:smoking]
   end
   
   def search
@@ -153,6 +155,12 @@ class CoffeeShopSearchService
     
     # コンセント
     srarch_by_outlet if @outlet.present?
+    
+    # wifi
+    search_by_wifi if @wifi.present?
+    
+    # 喫煙
+    search_by_smoking if @smoking.present?
     
     @coffee_shops
   end
@@ -452,6 +460,16 @@ class CoffeeShopSearchService
   # コンセント
   def srarch_by_outlet
     @coffee_shops = @coffee_shops.where(outlet: @outlet)
+  end
+  
+  # wifi
+  def search_by_wifi
+    @coffee_shops = @coffee_shops.where(wifi: @wifi)
+  end
+  
+  # 喫煙
+  def search_by_smoking
+    @coffee_shops = @coffee_shops.where(smoking: @smoking)
   end
   
 end

--- a/app/service/coffee_shop_show_info_service.rb
+++ b/app/service/coffee_shop_show_info_service.rb
@@ -38,6 +38,8 @@ class CoffeeShopShowInfoService
     create_latte_price if @coffee_shop.latte_price.present?
     create_chair_type if @coffee_shop.chair_types.present?
     create_outlet if @coffee_shop.outlet.present?
+    create_wifi if @coffee_shop.wifi.present?
+    create_smoking if @coffee_shop.smoking.present?
     
     @shop_info
   end
@@ -345,6 +347,24 @@ class CoffeeShopShowInfoService
     hash.class
     hash[:title] = 'コンセント'
     hash[:value] = @coffee_shop.outlet_i18n
+    @shop_info << hash
+  end
+  
+  # Wi-Fi
+  def create_wifi
+    hash = {}
+    hash.class
+    hash[:title] = 'Wi-Fi'
+    hash[:value] = @coffee_shop.wifi_i18n
+    @shop_info << hash
+  end
+  
+  # 喫煙
+  def create_smoking
+    hash = {}
+    hash.class
+    hash[:title] = '喫煙・禁煙'
+    hash[:value] = @coffee_shop.smoking_i18n
     @shop_info << hash
   end
   

--- a/app/service/coffee_shop_show_info_service.rb
+++ b/app/service/coffee_shop_show_info_service.rb
@@ -37,7 +37,8 @@ class CoffeeShopShowInfoService
     create_coffee_price if @coffee_shop.coffee_price.present?
     create_latte_price if @coffee_shop.latte_price.present?
     create_chair_type if @coffee_shop.chair_types.present?
-     
+    create_outlet if @coffee_shop.outlet.present?
+    
     @shop_info
   end
   
@@ -335,6 +336,15 @@ class CoffeeShopShowInfoService
     hash.class
     hash[:title] = '椅子の種類'
     hash[:value] = @coffee_shop.chair_types.pluck(:name).join(',')
+    @shop_info << hash
+  end
+  
+  # コンセント
+  def create_outlet
+    hash = {}
+    hash.class
+    hash[:title] = 'コンセント'
+    hash[:value] = @coffee_shop.outlet_i18n
     @shop_info << hash
   end
   

--- a/app/service/create_coffee_shop_search_conditions_service.rb
+++ b/app/service/create_coffee_shop_search_conditions_service.rb
@@ -41,6 +41,8 @@ class CreateCoffeeShopSearchConditionsService
     @latte_price_search_type = hash[:latte_price_search_type]
     @chair_type_ids = hash[:chair_type_ids]
     @outlet = hash[:outlet]
+    @wifi = hash[:wifi]
+    @smoking = hash[:smoking]
   end
   
   def create
@@ -81,6 +83,8 @@ class CreateCoffeeShopSearchConditionsService
     create_latte_price if @latte_price.present?
     create_chair_type if @chair_type_ids.present?
     create_outlet if @outlet.present?
+    create_wifi if @wifi.present?
+    create_smoking if @smoking.present?
     
     @coffee_shop_search_conditions
   end
@@ -251,6 +255,14 @@ class CreateCoffeeShopSearchConditionsService
   
   def create_outlet
     @coffee_shop_search_conditions << "コンセント：#{CoffeeShop.outlets_i18n[@outlet]}"
+  end
+  
+  def create_wifi
+    @coffee_shop_search_conditions << "Wi-Fi：#{CoffeeShop.wifis_i18n[@wifi]}"
+  end
+  
+  def create_smoking
+    @coffee_shop_search_conditions << "喫煙・禁煙：#{CoffeeShop.smokings_i18n[@smoking]}"
   end
   
 end

--- a/app/service/create_coffee_shop_search_conditions_service.rb
+++ b/app/service/create_coffee_shop_search_conditions_service.rb
@@ -40,6 +40,7 @@ class CreateCoffeeShopSearchConditionsService
     @latte_price = hash[:latte_price]
     @latte_price_search_type = hash[:latte_price_search_type]
     @chair_type_ids = hash[:chair_type_ids]
+    @outlet = hash[:outlet]
   end
   
   def create
@@ -79,6 +80,7 @@ class CreateCoffeeShopSearchConditionsService
     create_coffee_price if @coffee_price.present?
     create_latte_price if @latte_price.present?
     create_chair_type if @chair_type_ids.present?
+    create_outlet if @outlet.present?
     
     @coffee_shop_search_conditions
   end
@@ -245,6 +247,10 @@ class CreateCoffeeShopSearchConditionsService
     chair_types = ChairType.where(id: @chair_type_ids)
     return_message = "椅子の種類：#{chair_types.pluck(:name).join('or')}"
     @coffee_shop_search_conditions << return_message
+  end
+  
+  def create_outlet
+    @coffee_shop_search_conditions << "コンセント：#{CoffeeShop.outlets_i18n[@outlet]}"
   end
   
 end

--- a/app/views/shared/dashboard/_shop_info.html.erb
+++ b/app/views/shared/dashboard/_shop_info.html.erb
@@ -133,6 +133,10 @@
     <% end %>
   </div>
   コンセント：<%= f.select :outlet, CoffeeShop.outlets_i18n.invert, { include_blank: '選択してください'} %>
+  <br>
+  Wi-Fi：<%= f.select :wifi, CoffeeShop.wifis_i18n.invert, { include_blank: '選択してください'} %>
+  <br>
+  禁煙・喫煙：<%= f.select :smoking, CoffeeShop.smokings_i18n.invert, { include_blank: '選択してください'} %>
   <hr>
   <% if metod.eql?('edit') %>
     <%= f.submit "更新" %>

--- a/app/views/shared/dashboard/_shop_info.html.erb
+++ b/app/views/shared/dashboard/_shop_info.html.erb
@@ -132,7 +132,7 @@
       <%= chair_type.label { chair_type.check_box + chair_type.text } %>
     <% end %>
   </div>
-  
+  コンセント：<%= f.select :outlet, CoffeeShop.outlets_i18n.invert, { include_blank: '選択してください'} %>
   <hr>
   <% if metod.eql?('edit') %>
     <%= f.submit "更新" %>

--- a/app/views/web/search.html.erb
+++ b/app/views/web/search.html.erb
@@ -314,6 +314,16 @@
       <% end %>
     </div>
     
+    <div class="search-container">
+      <div class="search-name">コンセント</div>
+      <%= f.collection_radio_buttons(:outlet, CoffeeShop.outlets_i18n, :first, :last, {include_hidden: false}) do |outlet| %>
+        <div class="search-radio">
+          <%= outlet.radio_button %>
+          <%= outlet.label %>
+        </div>
+      <% end %>
+    </div>
+    
     <hr>
     <%= f.submit :search, :class => 'btn-search' %>
   <% end %> 

--- a/app/views/web/search.html.erb
+++ b/app/views/web/search.html.erb
@@ -324,6 +324,26 @@
       <% end %>
     </div>
     
+    <div class="search-container">
+      <div class="search-name">Wi-Fi</div>
+      <%= f.collection_radio_buttons(:wifi, CoffeeShop.wifis_i18n, :first, :last, {include_hidden: false}) do |wifi| %>
+        <div class="search-radio">
+          <%= wifi.radio_button %>
+          <%= wifi.label %>
+        </div>
+      <% end %>
+    </div>
+    
+    <div class="search-container">
+      <div class="search-name">喫煙・分煙</div>
+      <%= f.collection_radio_buttons(:smoking, CoffeeShop.smokings_i18n, :first, :last, {include_hidden: false}) do |smoking| %>
+        <div class="search-radio">
+          <%= smoking.radio_button %>
+          <%= smoking.label %>
+        </div>
+      <% end %>
+    </div>
+    
     <hr>
     <%= f.submit :search, :class => 'btn-search' %>
   <% end %> 

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,6 +1,7 @@
 ja:
   enums:
     coffee_shop:
-      terrace_seat:
-        ari: 'あり'
-        nasi: 'なし'
+      outlet:
+        none_seat: 'なし'
+        all_seat: 'あり'
+        part_seat: '一部席あり'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -5,3 +5,10 @@ ja:
         none_seat: 'なし'
         all_seat: 'あり'
         part_seat: '一部席あり'
+      wifi:
+        available: 'あり'
+        not_available: 'なし'
+      smoking:
+        smoking: '喫煙可能'
+        no_smoking: '禁煙'
+        separate_smoke: '分煙'

--- a/db/migrate/20220103030406_add_outlet.rb
+++ b/db/migrate/20220103030406_add_outlet.rb
@@ -1,0 +1,7 @@
+class AddOutlet < ActiveRecord::Migration[5.2]
+  def change
+    add_column :coffee_shops, :existence_outlet, :string
+    add_column :coffee_shops, :existence_wifi, :string
+    add_column :coffee_shops, :can_smoking, :string
+  end
+end

--- a/db/migrate/20220103042241_add_outletinteger.rb
+++ b/db/migrate/20220103042241_add_outletinteger.rb
@@ -1,0 +1,5 @@
+class AddOutletinteger < ActiveRecord::Migration[5.2]
+  def change
+    add_column :coffee_shops, :outlet, :integer
+  end
+end

--- a/db/migrate/20220103045723_add_wi_fi.rb
+++ b/db/migrate/20220103045723_add_wi_fi.rb
@@ -1,0 +1,6 @@
+class AddWiFi < ActiveRecord::Migration[5.2]
+  def change
+    add_column :coffee_shops, :wifi, :integer
+    add_column :coffee_shops, :smoking, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_03_042241) do
+ActiveRecord::Schema.define(version: 2022_01_03_045723) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -156,6 +156,8 @@ ActiveRecord::Schema.define(version: 2022_01_03_042241) do
     t.string "existence_wifi"
     t.string "can_smoking"
     t.integer "outlet"
+    t.integer "wifi"
+    t.integer "smoking"
   end
 
   create_table "day_of_weeks", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_25_075048) do
+ActiveRecord::Schema.define(version: 2022_01_03_042241) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -152,6 +152,10 @@ ActiveRecord::Schema.define(version: 2021_12_25_075048) do
     t.integer "shop_badget_lower"
     t.integer "coffee_price"
     t.integer "latte_price"
+    t.string "existence_outlet"
+    t.string "existence_wifi"
+    t.string "can_smoking"
+    t.integer "outlet"
   end
 
   create_table "day_of_weeks", force: :cascade do |t|


### PR DESCRIPTION
# 背景
- この機能が必要な理由
コンセントの有無、Wifiが利用可能か、タバコが吸えるかでユーザーが検索できるようにするため

- どういう機能なのか
店舗情報に、コンセント、WiFiの有無、喫煙・禁煙を登録し、検索できるようにする

- なぜこのPR単位なのか
簡単な検索条件でまとめてenumでの実装を学ぶため

# やったこと
## コードベース
- 設計方針
項目の内容が変わることはほぼないので、
enumを用いて項目の条件を登録できるようにする

- model
CoffeeShopテーブルにenumを追加する

- controller
他の検索項目と変わりないので、特に追記することはなし

- view
他の検索項目と変わりないので、特に追記することはなし

# 画面レイアウト
- 店舗情報登録画面
![image](https://user-images.githubusercontent.com/87374457/147901916-ab8ace05-e1b8-46e7-8402-046d3a2fbcad.png)

- 検索画面
![image](https://user-images.githubusercontent.com/87374457/147901926-afb11924-4ac4-4dc1-a0ae-bf557d99e19e.png)

- 店舗情報詳細画面
![image](https://user-images.githubusercontent.com/87374457/147901901-e539fd7a-08f6-4a8b-a5e8-69fa65106e30.png)

# 検証内容
- [x] 店舗情報に各項目を登録できるか
- [x] 店舗情報に登録されている各項目は変更ができるか
- [x] 登録されている各項目の情報は表示されているか
- [x] 各項目から検索ができるか