### PR TITLE
店員さんの雰囲気を検索項目に追加

### DIFF
--- a/app/controllers/coffee_shops_controller.rb
+++ b/app/controllers/coffee_shops_controller.rb
@@ -85,6 +85,7 @@ class CoffeeShopsController < ApplicationController
       hash[:wifi] = params[:wifi]
       hash[:smoking] = params[:smoking]
       hash[:use_scene_ids] = params[:use_scene_ids]
+      hash[:atmosphere_of_clerk_ids] = params[:atmosphere_of_clerk_ids]
       hash
     end
 end

--- a/app/controllers/dashboard/atmosphere_of_clerks_controller.rb
+++ b/app/controllers/dashboard/atmosphere_of_clerks_controller.rb
@@ -1,0 +1,59 @@
+class Dashboard::AtmosphereOfClerksController < ApplicationController
+  before_action :set_atmosphere_of_clerk, only: %w[show edit update destroy]
+  before_action :check_user_authority, except: :index
+  layout "dashboard/dashboard"
+  
+  def index
+    @atmosphere_of_clerks = AtmosphereOfClerk.all
+    @atmosphere_of_clerk = AtmosphereOfClerk.new
+  end
+  
+  def show
+  end
+  
+  def create
+    @atmosphere_of_clerk = AtmosphereOfClerk.new(atmosphere_of_clerk_params)
+    if @atmosphere_of_clerk.save
+      redirect_to dashboard_atmosphere_of_clerks_path, notice: '登録が完了しました'
+    else
+      flash[:alert] = @atmosphere_of_clerk.errors.full_messages
+      redirect_back(fallback_location: dashboard_atmosphere_of_clerks_path)
+    end
+  end
+  
+  def edit
+  end
+  
+  def update
+    if @atmosphere_of_clerk.update(atmosphere_of_clerk_params)
+      redirect_to dashboard_atmosphere_of_clerks_path, notice: '変更が完了しました。'
+    else
+      flash[:alert] = @atmosphere_of_clerk.errors.full_messages
+      redirect_back(fallback_location: dashboard_atmosphere_of_clerks_path)
+    end
+  end
+  
+  def destroy
+    @atmosphere_of_clerk.destroy
+    redirect_to dashboard_atmosphere_of_clerks_path
+  end
+  
+  private
+  
+  def set_atmosphere_of_clerk
+    @atmosphere_of_clerk = AtmosphereOfClerk.find(params[:id])
+  end
+  
+  def atmosphere_of_clerk_params
+    params.require(:atmosphere_of_clerk).permit(:name)
+  end
+  
+  def check_user_authority
+    @user = current_user
+    if @user.authority.eql?("2")
+      flash[:alert] = "アクセス権限がないです。"
+      redirect_to dashboard_path
+    end
+  end
+  
+end

--- a/app/controllers/dashboard/coffee_shops_controller.rb
+++ b/app/controllers/dashboard/coffee_shops_controller.rb
@@ -70,7 +70,7 @@ class Dashboard::CoffeeShopsController < ApplicationController
   
   def coffee_shop_params
     params.require(:coffee_shop).permit(:name, :shop_url, :address, :shop_tell, :access, :business_start_hour, :business_end_hour, :instagram_url, :instagram_spot_url, :municipalitie_id, :slack_time_start, :slack_time_end, :age_group, :shop_seats, :pc_work, :time_limit, :terrace_seat, :can_reserved, :comic, :magazine, :latte_art, :newspaper, :morning_menu, :parking_place, :free_water, :with_pet, :free_pc, :shop_badget_upper, :shop_badget_lower, :coffee_price, :latte_price, :outlet, :wifi, :smoking, 
-    { :search_category_ids => [], :shop_atmosphere_ids => [], :coffee_bean_ids => [], :volume_in_shop_ids => [], :food_menu_ids => [], :shop_bgm_ids => [], :shop_scenery_ids => [], :payment_method_ids => [], :chair_type_ids => [], :use_scene_ids => [] }, images: [])
+    { :search_category_ids => [], :shop_atmosphere_ids => [], :coffee_bean_ids => [], :volume_in_shop_ids => [], :food_menu_ids => [], :shop_bgm_ids => [], :shop_scenery_ids => [], :payment_method_ids => [], :chair_type_ids => [], :use_scene_ids => [], :atmosphere_of_clerk_ids => [] }, images: [])
   end
   
   def check_user_authority

--- a/app/models/atmosphere_of_clerk.rb
+++ b/app/models/atmosphere_of_clerk.rb
@@ -1,0 +1,13 @@
+class AtmosphereOfClerk < ApplicationRecord
+  has_many :coffee_shop_atmosphere_of_clerks, dependent: :destroy
+  has_many :coffee_shops, :through => :coffee_shop_atmosphere_of_clerks
+  
+  #空白禁止
+  validates :name, presence: true
+  
+  # 重複禁止
+	validates :name, uniqueness: true
+	
+	# 文字数
+	validates :name, length: { maximum: 15}
+end

--- a/app/models/coffee_shop.rb
+++ b/app/models/coffee_shop.rb
@@ -31,6 +31,9 @@ class CoffeeShop < ApplicationRecord
 	has_many :coffee_shop_use_scenes, dependent: :destroy
 	has_many :use_scenes, :through => :coffee_shop_use_scenes
 	
+	has_many :coffee_shop_atmosphere_of_clerks, dependent: :destroy
+	has_many :atmosphere_of_clerks, :through => :coffee_shop_atmosphere_of_clerks
+	
 	accepts_nested_attributes_for :coffee_shop_search_categories, allow_destroy: true
 	accepts_nested_attributes_for :coffee_shop_shop_atmospheres, allow_destroy: true
 	accepts_nested_attributes_for :coffee_shop_coffee_beans, allow_destroy: true
@@ -41,6 +44,7 @@ class CoffeeShop < ApplicationRecord
 	accepts_nested_attributes_for :coffee_shop_payment_methods, allow_destroy: true
 	accepts_nested_attributes_for :coffee_shop_chair_types, allow_destroy: true
 	accepts_nested_attributes_for :coffee_shop_use_scenes, allow_destroy: true
+	accepts_nested_attributes_for :coffee_shop_atmosphere_of_clerks, allow_destroy: true
 	acts_as_likeable
 	has_many_attached :images
 	

--- a/app/models/coffee_shop_atmosphere_of_clerk.rb
+++ b/app/models/coffee_shop_atmosphere_of_clerk.rb
@@ -1,0 +1,4 @@
+class CoffeeShopAtmosphereOfClerk < ApplicationRecord
+  belongs_to :coffee_shop
+  belongs_to :atmosphere_of_clerk
+end

--- a/app/service/coffee_shop_search_service.rb
+++ b/app/service/coffee_shop_search_service.rb
@@ -44,6 +44,7 @@ class CoffeeShopSearchService
     @wifi = hash[:wifi]
     @smoking = hash[:smoking]
     @use_scene_ids = hash[:use_scene_ids]
+    @atmosphere_of_clerk_ids = hash[:atmosphere_of_clerk_ids]
   end
   
   def search
@@ -165,6 +166,9 @@ class CoffeeShopSearchService
     
     # 利用シーン
     search_by_use_scene if @use_scene_ids.present?
+    
+    # 店員さんの雰囲気
+    search_by_atmosphere_of_clerk if @atmosphere_of_clerk_ids.present?
     
     @coffee_shops
   end
@@ -479,6 +483,12 @@ class CoffeeShopSearchService
   # 利用シーン
   def search_by_use_scene
     coffee_shop_ids = CoffeeShopUseScene.where(use_scene_id: @use_scene_ids).pluck(:coffee_shop_id)
+    @coffee_shops = @coffee_shops.where(id: coffee_shop_ids)
+  end
+  
+  # 店員さんの雰囲気
+  def search_by_atmosphere_of_clerk
+    coffee_shop_ids = CoffeeShopAtmosphereOfClerk.where(atmosphere_of_clerk_id: @atmosphere_of_clerk_ids).pluck(:coffee_shop_id)
     @coffee_shops = @coffee_shops.where(id: coffee_shop_ids)
   end
   

--- a/app/service/coffee_shop_show_info_service.rb
+++ b/app/service/coffee_shop_show_info_service.rb
@@ -41,6 +41,7 @@ class CoffeeShopShowInfoService
     create_wifi if @coffee_shop.wifi.present?
     create_smoking if @coffee_shop.smoking.present?
     create_use_scene if @coffee_shop.use_scenes.present?
+    create_atmosphere_of_clerk if @coffee_shop.atmosphere_of_clerks.present?
     
     @shop_info
   end
@@ -375,6 +376,15 @@ class CoffeeShopShowInfoService
     hash.class
     hash[:title] = '利用シーン'
     hash[:value] = @coffee_shop.use_scenes.pluck(:name).join(',')
+    @shop_info << hash
+  end
+  
+  # 店員さんの雰囲気
+  def create_atmosphere_of_clerk
+    hash = {}
+    hash.class
+    hash[:title] = '店員さんの雰囲気'
+    hash[:value] = @coffee_shop.atmosphere_of_clerks.pluck(:name).join(',')
     @shop_info << hash
   end
   

--- a/app/service/create_coffee_shop_search_conditions_service.rb
+++ b/app/service/create_coffee_shop_search_conditions_service.rb
@@ -44,6 +44,7 @@ class CreateCoffeeShopSearchConditionsService
     @wifi = hash[:wifi]
     @smoking = hash[:smoking]
     @use_scene_ids = hash[:use_scene_ids]
+    @atmosphere_of_clerk_ids = hash[:atmosphere_of_clerk_ids]
   end
   
   def create
@@ -87,6 +88,7 @@ class CreateCoffeeShopSearchConditionsService
     create_wifi if @wifi.present?
     create_smoking if @smoking.present?
     create_use_scene if @use_scene_ids.present?
+    create_atmosphere_of_clerk if @atmosphere_of_clerk_ids.present?
     
     @coffee_shop_search_conditions
   end
@@ -274,6 +276,13 @@ class CreateCoffeeShopSearchConditionsService
   def create_use_scene
     use_scenes = UseScene.where(id: @use_scene_ids)
     return_message = "利用シーン：#{use_scenes.pluck(:name).join('or')}"
+    @coffee_shop_search_conditions << return_message
+  end
+  
+  # 店員さんの雰囲気
+  def create_atmosphere_of_clerk
+    atmosphere_of_clerks = AtmosphereOfClerk.where(id: @atmosphere_of_clerk_ids)
+    return_message = "店員さんの雰囲気:#{atmosphere_of_clerks.pluck(:name).join('or')}"
     @coffee_shop_search_conditions << return_message
   end
   

--- a/app/views/dashboard/atmosphere_of_clerks/edit.html.erb
+++ b/app/views/dashboard/atmosphere_of_clerks/edit.html.erb
@@ -1,0 +1,9 @@
+<h1>店員さんの雰囲気編集</h1>
+
+<%= form_with model: @atmosphere_of_clerk, url: dashboard_atmosphere_of_clerk_path(@atmosphere_of_clerk), local: true do |f| %>
+  <%= f.label :name, "店員さんの雰囲気" %>
+  <%= f.text_field :name %>
+  
+  <%= f.submit "更新" %>
+<% end %>
+<%= link_to "店員さんの雰囲気一覧に戻る", dashboard_atmosphere_of_clerks_path %>

--- a/app/views/dashboard/atmosphere_of_clerks/index.html.erb
+++ b/app/views/dashboard/atmosphere_of_clerks/index.html.erb
@@ -1,0 +1,3 @@
+<%= render partial: 'shared/dashboard/search_items_index', locals: 
+{ item_name: '店員さんの雰囲気', search_item: @atmosphere_of_clerk, search_items_path: dashboard_atmosphere_of_clerks_path,
+search_items: @atmosphere_of_clerks, items: 'atmosphere_of_clerks', itemp: 'atmosphere_of_clerk' } %>

--- a/app/views/layouts/dashboard/_sidebar.html.erb
+++ b/app/views/layouts/dashboard/_sidebar.html.erb
@@ -32,4 +32,6 @@
     <%= link_to "椅子の種類一覧", dashboard_chair_types_path %>
   <br>
     <%= link_to "利用シーン一覧", dashboard_use_scenes_path %>
+  <br>
+    <%= link_to "店員さんの雰囲気一覧", dashboard_atmosphere_of_clerks_path %>
 </div>

--- a/app/views/shared/dashboard/_shop_info.html.erb
+++ b/app/views/shared/dashboard/_shop_info.html.erb
@@ -41,7 +41,7 @@
       <img id="image-preview",size="50x50">
     </div>
   </div>
-  検索カテゴリ<br>
+  こだわり<br>
   <div class="check_box">
     <%= f.collection_check_boxes(:search_category_ids, SearchCategory.all, :id, :name) do |search_category| %>
       <%= search_category.label { search_category.check_box + search_category.text } %>
@@ -142,6 +142,12 @@
   <div class="check_box">
     <%= f.collection_check_boxes(:use_scene_ids, UseScene.all, :id, :name) do |use_scene| %>
       <%= use_scene.label { use_scene.check_box + use_scene.text } %>
+    <% end %>
+  </div>
+  店員さんの雰囲気<br>
+  <div class="check_box">
+    <%= f.collection_check_boxes(:atmosphere_of_clerk_ids, AtmosphereOfClerk.all, :id, :name) do |atmosphere_of_clerk| %>
+      <%= atmosphere_of_clerk.label { atmosphere_of_clerk.check_box + atmosphere_of_clerk.text } %>
     <% end %>
   </div>
   <hr>

--- a/app/views/web/search.html.erb
+++ b/app/views/web/search.html.erb
@@ -354,6 +354,16 @@
       <% end %>
     </div>
     
+    <div class="search-container">
+      <div class="search-name">店員さんの雰囲気</div>
+      <%= f.collection_check_boxes(:atmosphere_of_clerk_ids, AtmosphereOfClerk.all, :id, :name, {include_hidden: false}) do |atmosphere_of_clerk| %>
+        <div class="search-checkbox">
+          <%= atmosphere_of_clerk.check_box %>
+          <%= atmosphere_of_clerk.label %>
+        </div>
+      <% end %>
+    </div>
+    
     <hr>
     <%= f.submit :search, :class => 'btn-search' %>
   <% end %> 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,7 @@ Rails.application.routes.draw do
     resources :payment_methods, except: [:new]
     resources :chair_types, except: [:new]
     resources :use_scenes, except: [:new]
+    resources :atmosphere_of_clerks, except: [:new]
   end
   
   devise_for :users, :controllers => {

--- a/db/migrate/20220106100424_create_atmosphere_of_clerks.rb
+++ b/db/migrate/20220106100424_create_atmosphere_of_clerks.rb
@@ -1,0 +1,9 @@
+class CreateAtmosphereOfClerks < ActiveRecord::Migration[5.2]
+  def change
+    create_table :atmosphere_of_clerks do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220106100510_create_coffee_shop_atmosphere_of_clerks.rb
+++ b/db/migrate/20220106100510_create_coffee_shop_atmosphere_of_clerks.rb
@@ -1,0 +1,10 @@
+class CreateCoffeeShopAtmosphereOfClerks < ActiveRecord::Migration[5.2]
+  def change
+    create_table :coffee_shop_atmosphere_of_clerks do |t|
+      t.integer :coffee_shop_id
+      t.integer :atmosphere_of_clerk_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_04_095255) do
+ActiveRecord::Schema.define(version: 2022_01_06_100510) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -39,6 +39,12 @@ ActiveRecord::Schema.define(version: 2022_01_04_095255) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "atmosphere_of_clerks", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "chair_types", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
@@ -47,6 +53,13 @@ ActiveRecord::Schema.define(version: 2022_01_04_095255) do
 
   create_table "coffee_beans", force: :cascade do |t|
     t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "coffee_shop_atmosphere_of_clerks", force: :cascade do |t|
+    t.integer "coffee_shop_id"
+    t.integer "atmosphere_of_clerk_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/test/fixtures/atmosphere_of_clerks.yml
+++ b/test/fixtures/atmosphere_of_clerks.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/coffee_shop_atmosphere_of_clerks.yml
+++ b/test/fixtures/coffee_shop_atmosphere_of_clerks.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/atmosphere_of_clerk_test.rb
+++ b/test/models/atmosphere_of_clerk_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class AtmosphereOfClerkTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/coffee_shop_atmosphere_of_clerk_test.rb
+++ b/test/models/coffee_shop_atmosphere_of_clerk_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class CoffeeShopAtmosphereOfClerkTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# 背景
- この機能が必要な理由
店員さんの雰囲気から店舗が検索できることで、
自分好みのお店が検索できる。
店舗詳細画面で店員さんの雰囲気を表示することで、
来店の際に事前に知ることができる

- どういう機能なのか
店舗を店員さんの雰囲気から検索ができる
店舗詳細画面に店員さんの雰囲気の情報が表示できる

- なぜこのPR単位なのか
店員さんの雰囲気でまとめるため

# やったこと
## コードベース
- 設計方針
店員さんの雰囲気は編集等ができるために、
コーヒーショップのカラムに追加ではなく、
中間テーブルを用いて、コーヒーショップと紐付けをする

- model
他の中間テーブルを用いた項目と変わりないので省略

- controller
他の中間テーブルを用いた項目と変わりないので省略

- view
他の中間テーブルを用いた項目と変わりないので省略

# 画面レイアウト
- 店員さんの雰囲気一覧
![image](https://user-images.githubusercontent.com/87374457/148668534-bbcf6eed-cfa5-4c94-b8c1-75ab7b50458d.png)

- 検索画面
![image](https://user-images.githubusercontent.com/87374457/148668543-70be1d80-70e7-4161-950b-71833562d98c.png)

- 店舗詳細画面
![image](https://user-images.githubusercontent.com/87374457/148668581-a6a695a7-d1a6-4d7a-829a-8a5055002b08.png)

# 検証内容
- [x] 店員さんの雰囲気が新規追加できるか
- [x] 店員さんの雰囲気が編集できるか
- [x] 店員さんの雰囲気が削除できるか
- [x] 店員さんの雰囲気を店舗に登録できるか
- [x] 店舗に登録されている店員さんの雰囲気は編集ができるか
- [x] 店員さんの雰囲気は検索項目に表示されているか
- [x] 店員さんの雰囲気から店舗の検索ができるか
- [x] 店舗詳細画面い店員さんの雰囲気は表示されているか