### PR TITLE
検索項目に机の広さを追加

### DIFF
--- a/app/controllers/coffee_shops_controller.rb
+++ b/app/controllers/coffee_shops_controller.rb
@@ -86,6 +86,7 @@ class CoffeeShopsController < ApplicationController
       hash[:smoking] = params[:smoking]
       hash[:use_scene_ids] = params[:use_scene_ids]
       hash[:atmosphere_of_clerk_ids] = params[:atmosphere_of_clerk_ids]
+      hash[:size_of_desk_ids] = params[:size_of_desk_ids]
       hash
     end
 end

--- a/app/controllers/dashboard/atmosphere_of_clerks_controller.rb
+++ b/app/controllers/dashboard/atmosphere_of_clerks_controller.rb
@@ -8,9 +8,6 @@ class Dashboard::AtmosphereOfClerksController < ApplicationController
     @atmosphere_of_clerk = AtmosphereOfClerk.new
   end
   
-  def show
-  end
-  
   def create
     @atmosphere_of_clerk = AtmosphereOfClerk.new(atmosphere_of_clerk_params)
     if @atmosphere_of_clerk.save

--- a/app/controllers/dashboard/chair_types_controller.rb
+++ b/app/controllers/dashboard/chair_types_controller.rb
@@ -8,9 +8,6 @@ class Dashboard::ChairTypesController < ApplicationController
     @chair_type = ChairType.new
   end
   
-  def show
-  end
-  
   def create
     @chair_type = ChairType.new(chair_type_params)
     if @chair_type.save

--- a/app/controllers/dashboard/coffee_beans_controller.rb
+++ b/app/controllers/dashboard/coffee_beans_controller.rb
@@ -8,9 +8,6 @@ class Dashboard::CoffeeBeansController < ApplicationController
     @coffee_bean = CoffeeBean.new
   end
   
-  def show
-  end
-  
   def create
     @coffee_bean = CoffeeBean.new(coffee_bean_params)
     if @coffee_bean.save

--- a/app/controllers/dashboard/coffee_shops_controller.rb
+++ b/app/controllers/dashboard/coffee_shops_controller.rb
@@ -15,9 +15,6 @@ class Dashboard::CoffeeShopsController < ApplicationController
     end
   end
   
-  def show
-  end
-
   def new
     @coffee_shop = CoffeeShop.new
     set_municipality_tags

--- a/app/controllers/dashboard/coffee_shops_controller.rb
+++ b/app/controllers/dashboard/coffee_shops_controller.rb
@@ -67,7 +67,7 @@ class Dashboard::CoffeeShopsController < ApplicationController
   
   def coffee_shop_params
     params.require(:coffee_shop).permit(:name, :shop_url, :address, :shop_tell, :access, :business_start_hour, :business_end_hour, :instagram_url, :instagram_spot_url, :municipalitie_id, :slack_time_start, :slack_time_end, :age_group, :shop_seats, :pc_work, :time_limit, :terrace_seat, :can_reserved, :comic, :magazine, :latte_art, :newspaper, :morning_menu, :parking_place, :free_water, :with_pet, :free_pc, :shop_badget_upper, :shop_badget_lower, :coffee_price, :latte_price, :outlet, :wifi, :smoking, 
-    { :search_category_ids => [], :shop_atmosphere_ids => [], :coffee_bean_ids => [], :volume_in_shop_ids => [], :food_menu_ids => [], :shop_bgm_ids => [], :shop_scenery_ids => [], :payment_method_ids => [], :chair_type_ids => [], :use_scene_ids => [], :atmosphere_of_clerk_ids => [] }, images: [])
+    { :search_category_ids => [], :shop_atmosphere_ids => [], :coffee_bean_ids => [], :volume_in_shop_ids => [], :food_menu_ids => [], :shop_bgm_ids => [], :shop_scenery_ids => [], :payment_method_ids => [], :chair_type_ids => [], :use_scene_ids => [], :atmosphere_of_clerk_ids => [], :size_of_desk_ids => [] }, images: [])
   end
   
   def check_user_authority

--- a/app/controllers/dashboard/food_menus_controller.rb
+++ b/app/controllers/dashboard/food_menus_controller.rb
@@ -8,9 +8,6 @@ class Dashboard::FoodMenusController < ApplicationController
     @food_menu = FoodMenu.new
   end
   
-  def show
-  end
-  
   def create
     @food_menu = FoodMenu.new(food_menu_params)
     if @food_menu.save

--- a/app/controllers/dashboard/municipalities_controller.rb
+++ b/app/controllers/dashboard/municipalities_controller.rb
@@ -9,9 +9,6 @@ class Dashboard::MunicipalitiesController < ApplicationController
     @municipality = Municipality.new
   end
   
-  def show
-  end
-  
   def create
     @municipality = Municipality.new(municipality_params)
     @municipality.save

--- a/app/controllers/dashboard/payment_methods_controller.rb
+++ b/app/controllers/dashboard/payment_methods_controller.rb
@@ -8,9 +8,6 @@ class Dashboard::PaymentMethodsController < ApplicationController
     @payment_method = PaymentMethod.new
   end
   
-  def show
-  end
-  
   def create
     @payment_method = PaymentMethod.new(payment_method_params)
     if @payment_method.save

--- a/app/controllers/dashboard/prefectures_controller.rb
+++ b/app/controllers/dashboard/prefectures_controller.rb
@@ -8,9 +8,6 @@ class Dashboard::PrefecturesController < ApplicationController
     @prefecture = Prefecture.new
   end
   
-  def show
-  end
-  
   def create
     @prefecture = Prefecture.new(prefecture_params)
     @prefecture.save

--- a/app/controllers/dashboard/search_categories_controller.rb
+++ b/app/controllers/dashboard/search_categories_controller.rb
@@ -8,9 +8,6 @@ class Dashboard::SearchCategoriesController < ApplicationController
     @search_category = SearchCategory.new
   end
   
-  def show
-  end
-  
   def create
     @search_category = SearchCategory.new(search_category_params)
     if @search_category.save

--- a/app/controllers/dashboard/shop_atmospheres_controller.rb
+++ b/app/controllers/dashboard/shop_atmospheres_controller.rb
@@ -8,9 +8,6 @@ class Dashboard::ShopAtmospheresController < ApplicationController
     @shop_atmosphere = ShopAtmosphere.new
   end
   
-  def show
-  end
-  
   def create
     @shop_atmosphere = ShopAtmosphere.new(shop_atmosphere_params)
     if @shop_atmosphere.save

--- a/app/controllers/dashboard/shop_bgms_controller.rb
+++ b/app/controllers/dashboard/shop_bgms_controller.rb
@@ -8,9 +8,6 @@ class Dashboard::ShopBgmsController < ApplicationController
     @shop_bgm = ShopBgm.new
   end
   
-  def show
-  end
-  
   def create
     @shop_bgm = ShopBgm.new(shop_bgm_params)
     if @shop_bgm.save

--- a/app/controllers/dashboard/shop_sceneries_controller.rb
+++ b/app/controllers/dashboard/shop_sceneries_controller.rb
@@ -8,9 +8,6 @@ class Dashboard::ShopSceneriesController < ApplicationController
     @shop_scenery = ShopScenery.new
   end
   
-  def show
-  end
-  
   def create
     @shop_scenery = ShopScenery.new(shop_scenery_params)
     if @shop_scenery.save

--- a/app/controllers/dashboard/size_of_desks_controller.rb
+++ b/app/controllers/dashboard/size_of_desks_controller.rb
@@ -1,0 +1,56 @@
+class Dashboard::SizeOfDesksController < ApplicationController
+  before_action :set_size_of_desk, only: %w[show edit update destroy]
+  before_action :check_user_authority, except: :index
+  layout "dashboard/dashboard"
+  
+  def index
+    @size_of_desks = SizeOfDesk.all
+    @size_of_desk = SizeOfDesk.new
+  end
+
+  def create
+    @size_of_desk = SizeOfDesk.new(size_of_desk_params)
+    if @size_of_desk.save
+      redirect_to dashboard_size_of_desks_path, notice: '登録が完了しました'
+    else
+      flash[:alert] = @size_of_desk.errors.full_messages
+      redirect_back(fallback_location: dashboard_size_of_desks_path)
+    end
+  end
+  
+  def edit
+  end
+  
+  def update
+    if @size_of_desk.update(size_of_desk_params)
+      redirect_to dashboard_size_of_desks_path, notice: '変更が完了しました。'
+    else
+      flash[:alert] = @size_of_desk.errors.full_messages
+      redirect_back(fallback_location: dashboard_size_of_desks_path)
+    end
+  end
+  
+  def destroy
+    @size_of_desk.destroy
+    redirect_to dashboard_size_of_desks_path
+  end
+  
+  private
+  
+  def set_size_of_desk
+    @size_of_desk = SizeOfDesk.find(params[:id])
+  end
+  
+  def size_of_desk_params
+    params.require(:size_of_desk).permit(:name)
+  end
+  
+  def check_user_authority
+    @user = current_user
+    if @user.authority.eql?("2")
+      flash[:alert] = "アクセス権限がないです。"
+      redirect_to dashboard_path
+    end
+  end
+  
+end

--- a/app/controllers/dashboard/use_scenes_controller.rb
+++ b/app/controllers/dashboard/use_scenes_controller.rb
@@ -8,9 +8,6 @@ class Dashboard::UseScenesController < ApplicationController
     @use_scene = UseScene.new
   end
   
-  def show
-  end
-  
   def create
     @use_scene = UseScene.new(use_scene_params)
     if @use_scene.save

--- a/app/controllers/dashboard/volume_in_shops_controller.rb
+++ b/app/controllers/dashboard/volume_in_shops_controller.rb
@@ -8,9 +8,6 @@ class Dashboard::VolumeInShopsController < ApplicationController
     @volume_in_shop = VolumeInShop.new
   end
   
-  def show
-  end
-  
   def create
     @volume_in_shop = VolumeInShop.new(volume_in_shop_params)
     if @volume_in_shop.save

--- a/app/models/coffee_shop.rb
+++ b/app/models/coffee_shop.rb
@@ -34,6 +34,9 @@ class CoffeeShop < ApplicationRecord
 	has_many :coffee_shop_atmosphere_of_clerks, dependent: :destroy
 	has_many :atmosphere_of_clerks, :through => :coffee_shop_atmosphere_of_clerks
 	
+	has_many :coffee_shop_size_of_desks, dependent: :destroy
+	has_many :size_of_desks, :through => :coffee_shop_size_of_desks
+	
 	accepts_nested_attributes_for :coffee_shop_search_categories, allow_destroy: true
 	accepts_nested_attributes_for :coffee_shop_shop_atmospheres, allow_destroy: true
 	accepts_nested_attributes_for :coffee_shop_coffee_beans, allow_destroy: true
@@ -45,6 +48,7 @@ class CoffeeShop < ApplicationRecord
 	accepts_nested_attributes_for :coffee_shop_chair_types, allow_destroy: true
 	accepts_nested_attributes_for :coffee_shop_use_scenes, allow_destroy: true
 	accepts_nested_attributes_for :coffee_shop_atmosphere_of_clerks, allow_destroy: true
+	accepts_nested_attributes_for :coffee_shop_size_of_desks, allow_destroy: true
 	acts_as_likeable
 	has_many_attached :images
 	

--- a/app/models/coffee_shop_size_of_desk.rb
+++ b/app/models/coffee_shop_size_of_desk.rb
@@ -1,0 +1,4 @@
+class CoffeeShopSizeOfDesk < ApplicationRecord
+  belongs_to :coffee_shop
+  belongs_to :size_of_desk
+end

--- a/app/models/size_of_desk.rb
+++ b/app/models/size_of_desk.rb
@@ -1,0 +1,13 @@
+class SizeOfDesk < ApplicationRecord
+  has_many :coffee_shop_size_of_desks, dependent: :destroy
+  has_many :coffee_shops, :through => :coffee_shop_size_of_desks
+  
+  # 空白禁止
+  validates :name, presence: true
+  
+  # 重複禁止
+  validates :name, uniqueness: true
+  
+  # 文字数
+  validates :name, length: { maximum: 15 }
+end

--- a/app/service/coffee_shop_search_service.rb
+++ b/app/service/coffee_shop_search_service.rb
@@ -45,6 +45,7 @@ class CoffeeShopSearchService
     @smoking = hash[:smoking]
     @use_scene_ids = hash[:use_scene_ids]
     @atmosphere_of_clerk_ids = hash[:atmosphere_of_clerk_ids]
+    @size_of_desk_ids = hash[:size_of_desk_ids]
   end
   
   def search
@@ -169,6 +170,9 @@ class CoffeeShopSearchService
     
     # 店員さんの雰囲気
     search_by_atmosphere_of_clerk if @atmosphere_of_clerk_ids.present?
+    
+    # 机の広さ
+    search_by_size_of_desk if @size_of_desk_ids.present?
     
     @coffee_shops
   end
@@ -489,6 +493,12 @@ class CoffeeShopSearchService
   # 店員さんの雰囲気
   def search_by_atmosphere_of_clerk
     coffee_shop_ids = CoffeeShopAtmosphereOfClerk.where(atmosphere_of_clerk_id: @atmosphere_of_clerk_ids).pluck(:coffee_shop_id)
+    @coffee_shops = @coffee_shops.where(id: coffee_shop_ids)
+  end
+  
+  # 机の広さ
+  def search_by_size_of_desk
+    coffee_shop_ids = CoffeeShopSizeOfDesk.where(size_of_desk_id: @size_of_desk_ids).pluck(:coffee_shop_id)
     @coffee_shops = @coffee_shops.where(id: coffee_shop_ids)
   end
   

--- a/app/service/coffee_shop_show_info_service.rb
+++ b/app/service/coffee_shop_show_info_service.rb
@@ -42,6 +42,7 @@ class CoffeeShopShowInfoService
     create_smoking if @coffee_shop.smoking.present?
     create_use_scene if @coffee_shop.use_scenes.present?
     create_atmosphere_of_clerk if @coffee_shop.atmosphere_of_clerks.present?
+    create_size_of_desk if @coffee_shop.size_of_desks.present?
     
     @shop_info
   end
@@ -385,6 +386,15 @@ class CoffeeShopShowInfoService
     hash.class
     hash[:title] = '店員さんの雰囲気'
     hash[:value] = @coffee_shop.atmosphere_of_clerks.pluck(:name).join(',')
+    @shop_info << hash
+  end
+  
+  # 机の広さ
+  def create_size_of_desk
+    hash = {}
+    hash.class
+    hash[:title] = '机の広さ'
+    hash[:value] = @coffee_shop.size_of_desks.pluck(:name).join(',')
     @shop_info << hash
   end
   

--- a/app/service/create_coffee_shop_search_conditions_service.rb
+++ b/app/service/create_coffee_shop_search_conditions_service.rb
@@ -45,6 +45,7 @@ class CreateCoffeeShopSearchConditionsService
     @smoking = hash[:smoking]
     @use_scene_ids = hash[:use_scene_ids]
     @atmosphere_of_clerk_ids = hash[:atmosphere_of_clerk_ids]
+    @size_of_desk_ids = hash[:size_of_desk_ids]
   end
   
   def create
@@ -89,6 +90,7 @@ class CreateCoffeeShopSearchConditionsService
     create_smoking if @smoking.present?
     create_use_scene if @use_scene_ids.present?
     create_atmosphere_of_clerk if @atmosphere_of_clerk_ids.present?
+    create_size_of_desk if @size_of_desk_ids.present?
     
     @coffee_shop_search_conditions
   end
@@ -283,6 +285,13 @@ class CreateCoffeeShopSearchConditionsService
   def create_atmosphere_of_clerk
     atmosphere_of_clerks = AtmosphereOfClerk.where(id: @atmosphere_of_clerk_ids)
     return_message = "店員さんの雰囲気:#{atmosphere_of_clerks.pluck(:name).join('or')}"
+    @coffee_shop_search_conditions << return_message
+  end
+  
+  # 机の広さ
+  def create_size_of_desk
+    size_of_desks = SizeOfDesk.where(id: @size_of_desk_ids)
+    return_message = "机の広さ：#{size_of_desks.pluck(:name).join('or')}"
     @coffee_shop_search_conditions << return_message
   end
   

--- a/app/views/dashboard/size_of_desks/edit.html.erb
+++ b/app/views/dashboard/size_of_desks/edit.html.erb
@@ -1,0 +1,9 @@
+<h1>机の広さ編集</h1>
+
+<%= form_with model: @size_of_desk, url: dashboard_size_of_desk_path(@size_of_desk), local: true do |f| %>
+  <%= f.label :name, "机の広さ" %>
+  <%= f.text_field :name %>
+  
+  <%= f.submit "更新" %>
+<% end %>
+<%= link_to "机の広さ一覧に戻る", dashboard_size_of_desks_path %>

--- a/app/views/dashboard/size_of_desks/index.html.erb
+++ b/app/views/dashboard/size_of_desks/index.html.erb
@@ -1,0 +1,3 @@
+<%= render partial: 'shared/dashboard/search_items_index', locals: 
+{ item_name: '机の広さ', search_item: @size_of_desk, search_items_path: dashboard_size_of_desks_path,
+search_items: @size_of_desks, items: 'size_of_desks', itemp: 'size_of_desk' } %>

--- a/app/views/layouts/dashboard/_sidebar.html.erb
+++ b/app/views/layouts/dashboard/_sidebar.html.erb
@@ -34,4 +34,6 @@
     <%= link_to "利用シーン一覧", dashboard_use_scenes_path %>
   <br>
     <%= link_to "店員さんの雰囲気一覧", dashboard_atmosphere_of_clerks_path %>
+  <br>
+    <%= link_to "机の広さ一覧", dashboard_size_of_desks_path %>
 </div>

--- a/app/views/shared/dashboard/_shop_info.html.erb
+++ b/app/views/shared/dashboard/_shop_info.html.erb
@@ -117,7 +117,6 @@
       <%= payment_method.label { payment_method.check_box + payment_method.text } %>
     <% end %>
   </div>
-  <br>
   予算(上限)：<%= f.number_field :shop_badget_upper %>円
   <br>
   予算(下限)；<%= f.number_field :shop_badget_lower %>円
@@ -148,6 +147,12 @@
   <div class="check_box">
     <%= f.collection_check_boxes(:atmosphere_of_clerk_ids, AtmosphereOfClerk.all, :id, :name) do |atmosphere_of_clerk| %>
       <%= atmosphere_of_clerk.label { atmosphere_of_clerk.check_box + atmosphere_of_clerk.text } %>
+    <% end %>
+  </div>
+  机の広さ<br>
+  <div class="check_box">
+    <%= f.collection_check_boxes(:size_of_desk_ids, SizeOfDesk.all, :id, :name) do |size_of_desk| %>
+      <%= size_of_desk.label { size_of_desk.check_box + size_of_desk.text } %>
     <% end %>
   </div>
   <hr>

--- a/app/views/web/search.html.erb
+++ b/app/views/web/search.html.erb
@@ -364,6 +364,16 @@
       <% end %>
     </div>
     
+    <div class="search-container">
+      <div class="search-name">机の広さ</div>
+      <%= f.collection_check_boxes(:size_of_desk_ids, SizeOfDesk.all, :id, :name, {include_hidden: false}) do |size_of_desk| %>
+        <div class="search-checkbox">
+          <%= size_of_desk.check_box %>
+          <%= size_of_desk.label %>
+        </div>
+      <% end %>
+    </div>
+    
     <hr>
     <%= f.submit :search, :class => 'btn-search' %>
   <% end %> 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,7 @@ Rails.application.routes.draw do
     resources :chair_types, except: [:new]
     resources :use_scenes, except: [:new]
     resources :atmosphere_of_clerks, except: [:new]
+    resources :size_of_desks, except: [:new]
   end
   
   devise_for :users, :controllers => {

--- a/db/migrate/20220109043237_create_size_of_desks.rb
+++ b/db/migrate/20220109043237_create_size_of_desks.rb
@@ -1,0 +1,9 @@
+class CreateSizeOfDesks < ActiveRecord::Migration[5.2]
+  def change
+    create_table :size_of_desks do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220109043253_create_coffee_shop_size_of_desks.rb
+++ b/db/migrate/20220109043253_create_coffee_shop_size_of_desks.rb
@@ -1,0 +1,10 @@
+class CreateCoffeeShopSizeOfDesks < ActiveRecord::Migration[5.2]
+  def change
+    create_table :coffee_shop_size_of_desks do |t|
+      t.integer :coffee_shop_id
+      t.integer :size_of_desk_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_06_100510) do
+ActiveRecord::Schema.define(version: 2022_01_09_043253) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -116,6 +116,13 @@ ActiveRecord::Schema.define(version: 2022_01_06_100510) do
   create_table "coffee_shop_shop_sceneries", force: :cascade do |t|
     t.integer "coffee_shop_id"
     t.integer "shop_scenery_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "coffee_shop_size_of_desks", force: :cascade do |t|
+    t.integer "coffee_shop_id"
+    t.integer "size_of_desk_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
@@ -278,6 +285,12 @@ ActiveRecord::Schema.define(version: 2022_01_06_100510) do
   end
 
   create_table "shop_sceneries", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "size_of_desks", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/test/fixtures/coffee_shop_size_of_desks.yml
+++ b/test/fixtures/coffee_shop_size_of_desks.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/size_of_desks.yml
+++ b/test/fixtures/size_of_desks.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/coffee_shop_size_of_desk_test.rb
+++ b/test/models/coffee_shop_size_of_desk_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class CoffeeShopSizeOfDeskTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/size_of_desk_test.rb
+++ b/test/models/size_of_desk_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class SizeOfDeskTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# 背景
- この機能が必要な理由
机の広さから店舗の検索をできるようにし、
好みの机のひろさの店舗を見つけられるようにするため

- どういう機能なのか
店舗情報に机の広さを追加する
机の広さから店舗の検索ができる

- なぜこのPR単位なのか
机の広さでまとめるため

# やったこと
## コードベース
- 設計方針
机の広さは中間テーブルを用いて店舗と紐付けを行う
管理画面で机の広さは編集できるようにする

- model
他の中間テーブルを用いた項目と同じなので省略

- controller
他の中間テーブルを用いた項目と同じなので省略

- view
他の中間テーブルを用いた項目と同じなので省略

# 画面レイアウト
- 机の広さ一覧
![image](https://user-images.githubusercontent.com/87374457/148670725-78892e00-aaac-47e0-b03f-0ffcecdbf17d.png)

- 検索項目画面
![image](https://user-images.githubusercontent.com/87374457/148670729-1885ac38-7bb2-4cfe-b018-2d94ba7b2f06.png)

- 店舗詳細画面
![image](https://user-images.githubusercontent.com/87374457/148670734-0ff06b95-8b9f-4d60-8a19-a540d0d8f3f4.png)

# 検証内容
- [x] 机の広さを登録できるか
- [x] 机の広さは修正できるか
- [x] 机の広さは削除できるか
- [x] 店舗情報に机の広さは登録できるか
- [x] 店舗情報に登録されている机の広さは変更できるか
- [x] 検索条件に机の広さは表示されているか
- [x] 机の広さから店舗の検索ができるか
- [x] 店舗詳細に机の広さは表示されているか