### PR TITLE
ポイントカードを検索項目に追加

### DIFF
--- a/app/assets/stylesheets/coffee_shops.scss
+++ b/app/assets/stylesheets/coffee_shops.scss
@@ -141,6 +141,13 @@
   color: black;
 }
 
+.review {
+  position: relative;
+  color: #CC935B;
+  font-size: 1.5em;
+  top: -9px;
+}
+
 .review-totel-container {
   position: relative;
   border-bottom: 3px solid #CC935B;

--- a/app/controllers/coffee_shops_controller.rb
+++ b/app/controllers/coffee_shops_controller.rb
@@ -19,7 +19,7 @@ class CoffeeShopsController < ApplicationController
     @create_coffeee_shop_search_conditions_service = CreateCoffeeShopSearchConditionsService.new(set_search_hash)
     @coffee_shop_search_conditions = @create_coffeee_shop_search_conditions_service.create
     # 検索条件をもとに店舗を検索する
-    @coffee_shop_search_service = CoffeeShopSearchService.new(set_search_hash)
+    @coffee_shop_search_service = CoffeeShopSearchService.new(set_search_hash,current_user)
     coffee_shops = @coffee_shop_search_service.search
     @coffee_shops = coffee_shops.page(params[:page]).per(PER)
     @coffee_shops_count = coffee_shops.count
@@ -94,6 +94,7 @@ class CoffeeShopsController < ApplicationController
       hash[:have_insta_account] = params[:have_insta_account]
       hash[:amusement] = params[:amusement]
       hash[:look_by_instagram] = params[:look_by_instagram]
+      hash[:bookmark] = params[:bookmark]
       hash
     end
 end

--- a/app/controllers/coffee_shops_controller.rb
+++ b/app/controllers/coffee_shops_controller.rb
@@ -87,6 +87,7 @@ class CoffeeShopsController < ApplicationController
       hash[:use_scene_ids] = params[:use_scene_ids]
       hash[:atmosphere_of_clerk_ids] = params[:atmosphere_of_clerk_ids]
       hash[:size_of_desk_ids] = params[:size_of_desk_ids]
+      hash[:point_card_ids] = params[:point_card_ids]
       hash
     end
 end

--- a/app/controllers/coffee_shops_controller.rb
+++ b/app/controllers/coffee_shops_controller.rb
@@ -88,6 +88,12 @@ class CoffeeShopsController < ApplicationController
       hash[:atmosphere_of_clerk_ids] = params[:atmosphere_of_clerk_ids]
       hash[:size_of_desk_ids] = params[:size_of_desk_ids]
       hash[:point_card_ids] = params[:point_card_ids]
+      hash[:reservation] = params[:reservation]
+      hash[:take_out] = params[:take_out]
+      hash[:with_children] = params[:with_children]
+      hash[:have_insta_account] = params[:have_insta_account]
+      hash[:amusement] = params[:amusement]
+      hash[:look_by_instagram] = params[:look_by_instagram]
       hash
     end
 end

--- a/app/controllers/dashboard/coffee_shops_controller.rb
+++ b/app/controllers/dashboard/coffee_shops_controller.rb
@@ -66,7 +66,7 @@ class Dashboard::CoffeeShopsController < ApplicationController
   end
   
   def coffee_shop_params
-    params.require(:coffee_shop).permit(:name, :shop_url, :address, :shop_tell, :access, :business_start_hour, :business_end_hour, :instagram_url, :instagram_spot_url, :municipalitie_id, :slack_time_start, :slack_time_end, :age_group, :shop_seats, :pc_work, :time_limit, :terrace_seat, :can_reserved, :comic, :magazine, :latte_art, :newspaper, :morning_menu, :parking_place, :free_water, :with_pet, :free_pc, :shop_badget_upper, :shop_badget_lower, :coffee_price, :latte_price, :outlet, :wifi, :smoking, 
+    params.require(:coffee_shop).permit(:name, :shop_url, :address, :shop_tell, :access, :business_start_hour, :business_end_hour, :instagram_url, :instagram_spot_url, :municipalitie_id, :slack_time_start, :slack_time_end, :age_group, :shop_seats, :pc_work, :time_limit, :terrace_seat, :can_reserved, :comic, :magazine, :latte_art, :newspaper, :morning_menu, :parking_place, :free_water, :with_pet, :free_pc, :shop_badget_upper, :shop_badget_lower, :coffee_price, :latte_price, :outlet, :wifi, :smoking, :reservation, :take_out, :with_children, :have_insta_account, :amusement, :look_by_instagram, 
     { :search_category_ids => [], :shop_atmosphere_ids => [], :coffee_bean_ids => [], :volume_in_shop_ids => [], :food_menu_ids => [], :shop_bgm_ids => [], :shop_scenery_ids => [], :payment_method_ids => [], :chair_type_ids => [], :use_scene_ids => [], :atmosphere_of_clerk_ids => [], :size_of_desk_ids => [], :point_card_ids => [] }, images: [])
   end
   

--- a/app/controllers/dashboard/coffee_shops_controller.rb
+++ b/app/controllers/dashboard/coffee_shops_controller.rb
@@ -67,7 +67,7 @@ class Dashboard::CoffeeShopsController < ApplicationController
   
   def coffee_shop_params
     params.require(:coffee_shop).permit(:name, :shop_url, :address, :shop_tell, :access, :business_start_hour, :business_end_hour, :instagram_url, :instagram_spot_url, :municipalitie_id, :slack_time_start, :slack_time_end, :age_group, :shop_seats, :pc_work, :time_limit, :terrace_seat, :can_reserved, :comic, :magazine, :latte_art, :newspaper, :morning_menu, :parking_place, :free_water, :with_pet, :free_pc, :shop_badget_upper, :shop_badget_lower, :coffee_price, :latte_price, :outlet, :wifi, :smoking, 
-    { :search_category_ids => [], :shop_atmosphere_ids => [], :coffee_bean_ids => [], :volume_in_shop_ids => [], :food_menu_ids => [], :shop_bgm_ids => [], :shop_scenery_ids => [], :payment_method_ids => [], :chair_type_ids => [], :use_scene_ids => [], :atmosphere_of_clerk_ids => [], :size_of_desk_ids => [] }, images: [])
+    { :search_category_ids => [], :shop_atmosphere_ids => [], :coffee_bean_ids => [], :volume_in_shop_ids => [], :food_menu_ids => [], :shop_bgm_ids => [], :shop_scenery_ids => [], :payment_method_ids => [], :chair_type_ids => [], :use_scene_ids => [], :atmosphere_of_clerk_ids => [], :size_of_desk_ids => [], :point_card_ids => [] }, images: [])
   end
   
   def check_user_authority

--- a/app/controllers/dashboard/point_cards_controller.rb
+++ b/app/controllers/dashboard/point_cards_controller.rb
@@ -1,0 +1,56 @@
+class Dashboard::PointCardsController < ApplicationController
+  before_action :set_point_card, only: %w[show edit update destroy]
+  before_action :check_user_authority, except: :index
+  layout "dashboard/dashboard"
+  
+  def index
+    @point_cards = PointCard.all
+    @point_card = PointCard.new
+  end
+  
+  def create
+    @point_card = PointCard.new(point_card_params)
+    if @point_card.save
+      redirect_to dashboard_point_cards_path, notice: '登録が完了しました'
+    else
+      flash[:alert] = @point_card.errors.full_messages
+      redirect_back(fallback_location: dashboard_point_cards_path)
+    end
+  end
+  
+  def edit
+  end
+  
+  def update
+    if @point_card.update(point_card_params)
+      redirect_to dashboard_point_cards_path, notice: '変更が完了しました。'
+    else
+      flash[:alert] = @point_card.errors.full_messages
+      redirect_back(fallback_location: dashboard_point_cards_path)
+    end
+  end
+  
+  def destroy
+    @point_card.destroy
+    redirect_to dashboard_point_cards_path
+  end
+  
+  private
+  
+  def set_point_card
+    @point_card = PointCard.find(params[:id])
+  end
+  
+  def point_card_params
+    params.require(:point_card).permit(:name)
+  end
+  
+  def check_user_authority
+    @user = current_user
+    if @user.authority.eql?("2")
+      flash[:alert] = "アクセス権限がないです。"
+      redirect_to dashboard_path
+    end
+  end
+  
+end

--- a/app/models/coffee_shop.rb
+++ b/app/models/coffee_shop.rb
@@ -86,9 +86,15 @@ class CoffeeShop < ApplicationRecord
 	validate :shop_badget_lower_and_shop_badget_upper_must_be_set
 	
 	# enum
-	enum outlet: { none_seat: 0, all_seat: 1, part_seat: 2 }
-	enum wifi: { available: 0, not_available: 1 }
-	enum smoking: { smoking: 0, no_smoking: 1, separate_smoke: 2}
+	enum outlet: { none_seat: 0, all_seat: 1, part_seat: 2 }, _prefix: true
+	enum wifi: { available: 0, not_available: 1 }, _prefix: true
+	enum smoking: { smoking: 0, no_smoking: 1, separate_smoke: 2}, _prefix: true
+	enum reservation: { reservation_possible: 0, reservations_not_accepted: 1}, _prefix: true
+	enum take_out: { available: 0, not_available: 1 }, _prefix: true
+	enum with_children: { available: 0, not_available: 1 }, _prefix: true
+	enum have_insta_account: { have_account: 0, not_have_account: 1 }, _prefix: true
+	enum amusement: { exist: 0, not_exist: 1 }, _prefix: true
+	enum look_by_instagram: { exterior: 0, interior: 1, food: 2 }, _prefix: true
 	
 	scope :search_for_name_and_tell, -> (keyword) {
 		where("name LIKE ?", "%#{keyword}%").

--- a/app/models/coffee_shop.rb
+++ b/app/models/coffee_shop.rb
@@ -37,6 +37,9 @@ class CoffeeShop < ApplicationRecord
 	has_many :coffee_shop_size_of_desks, dependent: :destroy
 	has_many :size_of_desks, :through => :coffee_shop_size_of_desks
 	
+	has_many :coffee_shop_point_cards, dependent: :destroy
+	has_many :point_cards, :through => :coffee_shop_point_cards
+	
 	accepts_nested_attributes_for :coffee_shop_search_categories, allow_destroy: true
 	accepts_nested_attributes_for :coffee_shop_shop_atmospheres, allow_destroy: true
 	accepts_nested_attributes_for :coffee_shop_coffee_beans, allow_destroy: true
@@ -49,6 +52,7 @@ class CoffeeShop < ApplicationRecord
 	accepts_nested_attributes_for :coffee_shop_use_scenes, allow_destroy: true
 	accepts_nested_attributes_for :coffee_shop_atmosphere_of_clerks, allow_destroy: true
 	accepts_nested_attributes_for :coffee_shop_size_of_desks, allow_destroy: true
+	accepts_nested_attributes_for :coffee_shop_point_cards, allow_destroy: true
 	acts_as_likeable
 	has_many_attached :images
 	

--- a/app/models/coffee_shop_point_card.rb
+++ b/app/models/coffee_shop_point_card.rb
@@ -1,0 +1,4 @@
+class CoffeeShopPointCard < ApplicationRecord
+  belongs_to :coffee_shop
+  belongs_to :point_card
+end

--- a/app/models/point_card.rb
+++ b/app/models/point_card.rb
@@ -1,0 +1,13 @@
+class PointCard < ApplicationRecord
+  has_many :coffee_shop_point_cards, dependent: :destroy
+  has_many :coffee_shops, :through => :coffee_shop_point_cards
+  
+  #空白禁止
+  validates :name, presence: true
+  
+  # 重複禁止
+	validates :name, uniqueness: true
+	
+	# 文字数
+	validates :name, length: { maximum: 15}
+end

--- a/app/service/coffee_shop_search_service.rb
+++ b/app/service/coffee_shop_search_service.rb
@@ -46,6 +46,7 @@ class CoffeeShopSearchService
     @use_scene_ids = hash[:use_scene_ids]
     @atmosphere_of_clerk_ids = hash[:atmosphere_of_clerk_ids]
     @size_of_desk_ids = hash[:size_of_desk_ids]
+    @point_card_ids = hash[:point_card_ids]
   end
   
   def search
@@ -173,6 +174,7 @@ class CoffeeShopSearchService
     
     # 机の広さ
     search_by_size_of_desk if @size_of_desk_ids.present?
+    search_by_point_card if @point_card_ids.present?
     
     @coffee_shops
   end
@@ -502,4 +504,9 @@ class CoffeeShopSearchService
     @coffee_shops = @coffee_shops.where(id: coffee_shop_ids)
   end
   
+  # ポイントカード
+  def search_by_point_card
+    coffee_shop_ids = CoffeeShopPointCard.where(point_card_id: @point_card_ids).pluck(:coffee_shop_id)
+    @coffee_shops = @coffee_shops.where(id: coffee_shop_ids)
+  end
 end

--- a/app/service/coffee_shop_search_service.rb
+++ b/app/service/coffee_shop_search_service.rb
@@ -47,6 +47,12 @@ class CoffeeShopSearchService
     @atmosphere_of_clerk_ids = hash[:atmosphere_of_clerk_ids]
     @size_of_desk_ids = hash[:size_of_desk_ids]
     @point_card_ids = hash[:point_card_ids]
+    @reservation = hash[:reservation]
+    @take_out = hash[:take_out]
+    @with_children = hash[:with_children]
+    @have_insta_account = hash[:have_insta_account]
+    @amusement = hash[:amusement]
+    @look_by_instagram = hash[:look_by_instagram]
   end
   
   def search
@@ -175,6 +181,12 @@ class CoffeeShopSearchService
     # 机の広さ
     search_by_size_of_desk if @size_of_desk_ids.present?
     search_by_point_card if @point_card_ids.present?
+    search_by_reservation if @reservation.present?
+    search_by_take_out if @take_out.present?
+    search_by_with_children if @with_children.present?
+    search_by_have_insta_account if @have_insta_account.present?
+    search_by_amusement if @amusement.present?
+    search_by_look_by_instagram if @look_by_instagram.present?
     
     @coffee_shops
   end
@@ -509,4 +521,35 @@ class CoffeeShopSearchService
     coffee_shop_ids = CoffeeShopPointCard.where(point_card_id: @point_card_ids).pluck(:coffee_shop_id)
     @coffee_shops = @coffee_shops.where(id: coffee_shop_ids)
   end
+  
+  # 予約
+  def search_by_reservation
+    @coffee_shops = @coffee_shops.where(reservation: @reservation)
+  end
+  
+  # テイクアウト
+  def search_by_take_out
+    @coffee_shops = @coffee_shops.where(take_out: @take_out)
+  end
+  
+  # お子様連れ
+  def search_by_with_children
+    @coffee_shops = @coffee_shops.where(with_children: @with_children)
+  end
+  
+  # インスタのアカウント
+  def search_by_have_insta_account
+    @coffee_shops = @coffee_shops.where(have_insta_account: @have_insta_account)
+  end
+  
+  # アミューズメント
+  def search_by_amusement
+    @coffee_shops = @coffee_shops.where(amusement: @amusement)
+  end
+  
+  # インスタ映え
+  def search_by_look_by_instagram
+    @coffee_shops = @coffee_shops.where(look_by_instagram: @look_by_instagram)  
+  end
+  
 end

--- a/app/service/coffee_shop_show_info_service.rb
+++ b/app/service/coffee_shop_show_info_service.rb
@@ -47,7 +47,6 @@ class CoffeeShopShowInfoService
     create_reservation if @coffee_shop.reservation.present?
     create_take_out if @coffee_shop.take_out.present?
     create_with_children if @coffee_shop.with_children.present?
-    create_have_insta_account if @coffee_shop.have_insta_account.present?
     create_amusement if @coffee_shop.amusement.present?
     create_look_by_instagram if @coffee_shop.look_by_instagram.present?
     
@@ -438,15 +437,6 @@ class CoffeeShopShowInfoService
     hash.class
     hash[:title] = 'お子様連れ'
     hash[:value] = @coffee_shop.with_children_i18n
-    @shop_info << hash
-  end
-  
-  # インスタアカウント
-  def create_have_insta_account
-    hash = {}
-    hash.class
-    hash[:title] = 'Instagramアカウント'
-    hash[:value] = @coffee_shop.have_insta_account_i18n
     @shop_info << hash
   end
   

--- a/app/service/coffee_shop_show_info_service.rb
+++ b/app/service/coffee_shop_show_info_service.rb
@@ -44,6 +44,12 @@ class CoffeeShopShowInfoService
     create_atmosphere_of_clerk if @coffee_shop.atmosphere_of_clerks.present?
     create_size_of_desk if @coffee_shop.size_of_desks.present?
     create_point_card if @coffee_shop.point_cards.present?
+    create_reservation if @coffee_shop.reservation.present?
+    create_take_out if @coffee_shop.take_out.present?
+    create_with_children if @coffee_shop.with_children.present?
+    create_have_insta_account if @coffee_shop.have_insta_account.present?
+    create_amusement if @coffee_shop.amusement.present?
+    create_look_by_instagram if @coffee_shop.look_by_instagram.present?
     
     @shop_info
   end
@@ -405,6 +411,60 @@ class CoffeeShopShowInfoService
     hash.class
     hash[:title] = 'ポイントカード'
     hash[:value] = @coffee_shop.point_cards.pluck(:name).join(',')
+    @shop_info << hash
+  end
+  
+  # 予約
+  def create_reservation
+    hash = {}
+    hash.class
+    hash[:title] = '予約'
+    hash[:value] = @coffee_shop.reservation_i18n
+    @shop_info << hash
+  end
+  
+  # テイクアウト
+  def create_take_out
+    hash = {}
+    hash.class
+    hash[:title] = 'テイクアウト'
+    hash[:value] = @coffee_shop.take_out_i18n
+    @shop_info << hash
+  end
+  
+  # お子様連れ
+  def create_with_children
+    hash = {}
+    hash.class
+    hash[:title] = 'お子様連れ'
+    hash[:value] = @coffee_shop.with_children_i18n
+    @shop_info << hash
+  end
+  
+  # インスタアカウント
+  def create_have_insta_account
+    hash = {}
+    hash.class
+    hash[:title] = 'Instagramアカウント'
+    hash[:value] = @coffee_shop.have_insta_account_i18n
+    @shop_info << hash
+  end
+  
+  # アミューズメント
+  def create_amusement
+    hash = {}
+    hash.class
+    hash[:title] = 'アミューズメント'
+    hash[:value] = @coffee_shop.amusement_i18n
+    @shop_info << hash
+  end
+  
+  # インスタ映え
+  def create_look_by_instagram
+    hash = {}
+    hash.class
+    hash[:title] = 'インスタ映え'
+    hash[:value] = @coffee_shop.look_by_instagram_i18n
     @shop_info << hash
   end
   

--- a/app/service/coffee_shop_show_info_service.rb
+++ b/app/service/coffee_shop_show_info_service.rb
@@ -43,6 +43,7 @@ class CoffeeShopShowInfoService
     create_use_scene if @coffee_shop.use_scenes.present?
     create_atmosphere_of_clerk if @coffee_shop.atmosphere_of_clerks.present?
     create_size_of_desk if @coffee_shop.size_of_desks.present?
+    create_point_card if @coffee_shop.point_cards.present?
     
     @shop_info
   end
@@ -395,6 +396,15 @@ class CoffeeShopShowInfoService
     hash.class
     hash[:title] = '机の広さ'
     hash[:value] = @coffee_shop.size_of_desks.pluck(:name).join(',')
+    @shop_info << hash
+  end
+  
+  # ポイントカード
+  def create_point_card
+    hash = {}
+    hash.class
+    hash[:title] = 'ポイントカード'
+    hash[:value] = @coffee_shop.point_cards.pluck(:name).join(',')
     @shop_info << hash
   end
   

--- a/app/service/create_coffee_shop_search_conditions_service.rb
+++ b/app/service/create_coffee_shop_search_conditions_service.rb
@@ -53,6 +53,7 @@ class CreateCoffeeShopSearchConditionsService
     @have_insta_account = hash[:have_insta_account]
     @amusement = hash[:amusement]
     @look_by_instagram = hash[:look_by_instagram]
+    @bookmark = hash[:bookmark]
   end
   
   def create
@@ -105,6 +106,7 @@ class CreateCoffeeShopSearchConditionsService
     create_have_insta_account if @have_insta_account.present?
     create_amusement if @amusement.present?
     create_look_by_instagram if @look_by_instagram.present?
+    create_bookmark if @bookmark.present?
     
     @coffee_shop_search_conditions
   end
@@ -344,6 +346,12 @@ class CreateCoffeeShopSearchConditionsService
   # インスタ映え
   def create_look_by_instagram
     @coffee_shop_search_conditions << "インスタ映え：#{CoffeeShop.look_by_instagrams_i18n[@look_by_instagram]}"
+  end
+  
+  # お気に入り登録
+  def create_bookmark
+    @coffee_shop_search_conditions << "お気に入り登録：登録済み" if @bookmark.eql?("register") 
+    @coffee_shop_search_conditions << "おきにりお登録：未登録" if @bookmark.eql?("unregistered")
   end
   
 end

--- a/app/service/create_coffee_shop_search_conditions_service.rb
+++ b/app/service/create_coffee_shop_search_conditions_service.rb
@@ -47,6 +47,12 @@ class CreateCoffeeShopSearchConditionsService
     @atmosphere_of_clerk_ids = hash[:atmosphere_of_clerk_ids]
     @size_of_desk_ids = hash[:size_of_desk_ids]
     @point_card_ids = hash[:point_card_ids]
+    @reservation = hash[:reservation]
+    @take_out = hash[:take_out]
+    @with_children = hash[:with_children]
+    @have_insta_account = hash[:have_insta_account]
+    @amusement = hash[:amusement]
+    @look_by_instagram = hash[:look_by_instagram]
   end
   
   def create
@@ -93,6 +99,12 @@ class CreateCoffeeShopSearchConditionsService
     create_atmosphere_of_clerk if @atmosphere_of_clerk_ids.present?
     create_size_of_desk if @size_of_desk_ids.present?
     create_point_card if @point_card_ids.present?
+    create_reservation if @reservation.present?
+    create_take_out if @take_out.present?
+    create_with_children if @with_children.present?
+    create_have_insta_account if @have_insta_account.present?
+    create_amusement if @amusement.present?
+    create_look_by_instagram if @look_by_instagram.present?
     
     @coffee_shop_search_conditions
   end
@@ -303,5 +315,35 @@ class CreateCoffeeShopSearchConditionsService
     return_message = "ポイントカード：#{point_cards.pluck(:name).join('or')}"
     @coffee_shop_search_conditions << return_message
   end 
+  
+  # 予約
+  def create_reservation
+    @coffee_shop_search_conditions << "予約：#{CoffeeShop.reservations_i18n[@reservation]}"
+  end
+  
+  # テイクアウト
+  def create_take_out
+    @coffee_shop_search_conditions << "テイクアウト：#{CoffeeShop.take_outs_i18n[@take_out]}"
+  end
+  
+  # お子様連れ
+  def create_with_children
+    @coffee_shop_search_conditions << "お子様連れ：#{CoffeeShop.with_children_i18n[@with_children]}"
+  end
+  
+  # Instagramアカウント
+  def create_have_insta_account
+    @coffee_shop_search_conditions << "Instagramアカウント：#{CoffeeShop.have_insta_accounts_i18n[@have_insta_account]}"
+  end
+  
+  # アミューズメント
+  def create_amusement
+    @coffee_shop_search_conditions << "アミューズメント：#{CoffeeShop.amusements_i18n[@amusement]}"
+  end
+  
+  # インスタ映え
+  def create_look_by_instagram
+    @coffee_shop_search_conditions << "インスタ映え：#{CoffeeShop.look_by_instagrams_i18n[@look_by_instagram]}"
+  end
   
 end

--- a/app/service/create_coffee_shop_search_conditions_service.rb
+++ b/app/service/create_coffee_shop_search_conditions_service.rb
@@ -46,6 +46,7 @@ class CreateCoffeeShopSearchConditionsService
     @use_scene_ids = hash[:use_scene_ids]
     @atmosphere_of_clerk_ids = hash[:atmosphere_of_clerk_ids]
     @size_of_desk_ids = hash[:size_of_desk_ids]
+    @point_card_ids = hash[:point_card_ids]
   end
   
   def create
@@ -91,6 +92,7 @@ class CreateCoffeeShopSearchConditionsService
     create_use_scene if @use_scene_ids.present?
     create_atmosphere_of_clerk if @atmosphere_of_clerk_ids.present?
     create_size_of_desk if @size_of_desk_ids.present?
+    create_point_card if @point_card_ids.present?
     
     @coffee_shop_search_conditions
   end
@@ -294,5 +296,12 @@ class CreateCoffeeShopSearchConditionsService
     return_message = "机の広さ：#{size_of_desks.pluck(:name).join('or')}"
     @coffee_shop_search_conditions << return_message
   end
+  
+  # ポイントカード
+  def create_point_card
+    point_cards = PointCard.where(id: @point_card_ids)
+    return_message = "ポイントカード：#{point_cards.pluck(:name).join('or')}"
+    @coffee_shop_search_conditions << return_message
+  end 
   
 end

--- a/app/views/coffee_shops/show.html.erb
+++ b/app/views/coffee_shops/show.html.erb
@@ -49,6 +49,7 @@
 		  <% end %>
 	  </div>
 		<div class="review-totel-container">
+			<div class="review">Review</div>
 			<div class="review-totel-count">
 				<%= @reviews_count %>
 				<p>件</p>

--- a/app/views/dashboard/point_cards/edit.html.erb
+++ b/app/views/dashboard/point_cards/edit.html.erb
@@ -1,0 +1,9 @@
+<h1>ポイントカード編集</h1>
+
+<%= form_with model: @point_card, url: dashboard_point_card_path(@point_card), local: true do |f| %>
+  <%= f.label :name, "ポイントカード" %>
+  <%= f.text_field :name %>
+  
+  <%= f.submit "更新" %>
+<% end %>
+<%= link_to "ポイントカード一覧に戻る", dashboard_point_cards_path %>

--- a/app/views/dashboard/point_cards/index.html.erb
+++ b/app/views/dashboard/point_cards/index.html.erb
@@ -1,0 +1,3 @@
+<%= render partial: 'shared/dashboard/search_items_index', locals: 
+{ item_name: 'ポイントカード', search_item: @point_card, search_items_path: dashboard_point_cards_path,
+search_items: @point_cards, items: 'point_cards', itemp: 'point_card' } %>

--- a/app/views/layouts/dashboard/_sidebar.html.erb
+++ b/app/views/layouts/dashboard/_sidebar.html.erb
@@ -36,4 +36,6 @@
     <%= link_to "店員さんの雰囲気一覧", dashboard_atmosphere_of_clerks_path %>
   <br>
     <%= link_to "机の広さ一覧", dashboard_size_of_desks_path %>
+  <br>
+    <%= link_to "ポイントカード一覧", dashboard_point_cards_path %>
 </div>

--- a/app/views/shared/dashboard/_shop_info.html.erb
+++ b/app/views/shared/dashboard/_shop_info.html.erb
@@ -161,6 +161,17 @@
       <%= point_card.label { point_card.check_box + point_card.text } %>
     <% end %>
   </div>
+  予約：<%= f.select :reservation, CoffeeShop.reservations_i18n.invert, { include_blank: '選択してください'} %>
+  <br>
+  テイクアウト：<%= f.select :take_out, CoffeeShop.take_outs_i18n.invert, { include_blank: '選択してください'} %>
+  <br>
+  お子様連れ：<%= f.select :with_children, CoffeeShop.with_children_i18n.invert, { include_blank: '選択してください'} %>
+  <br>
+  Instagramのアカウント：<%= f.select :have_insta_account, CoffeeShop.have_insta_accounts_i18n.invert, { include_blank: '選択してください'} %>
+  <br>
+  アミューズメント：<%= f.select :amusement, CoffeeShop.amusements_i18n.invert, { include_blank: '選択してください'} %>
+  <br>
+  インスタ映え：<%= f.select :look_by_instagram, CoffeeShop.look_by_instagrams_i18n.invert, { include_blank: '選択してください'} %>
   <hr>
   <% if metod.eql?('edit') %>
     <%= f.submit "更新" %>

--- a/app/views/shared/dashboard/_shop_info.html.erb
+++ b/app/views/shared/dashboard/_shop_info.html.erb
@@ -167,8 +167,6 @@
   <br>
   お子様連れ：<%= f.select :with_children, CoffeeShop.with_children_i18n.invert, { include_blank: '選択してください'} %>
   <br>
-  Instagramのアカウント：<%= f.select :have_insta_account, CoffeeShop.have_insta_accounts_i18n.invert, { include_blank: '選択してください'} %>
-  <br>
   アミューズメント：<%= f.select :amusement, CoffeeShop.amusements_i18n.invert, { include_blank: '選択してください'} %>
   <br>
   インスタ映え：<%= f.select :look_by_instagram, CoffeeShop.look_by_instagrams_i18n.invert, { include_blank: '選択してください'} %>

--- a/app/views/shared/dashboard/_shop_info.html.erb
+++ b/app/views/shared/dashboard/_shop_info.html.erb
@@ -155,6 +155,12 @@
       <%= size_of_desk.label { size_of_desk.check_box + size_of_desk.text } %>
     <% end %>
   </div>
+  ポイントカード<br>
+  <div class="check_box">
+    <%= f.collection_check_boxes(:point_card_ids, PointCard.all, :id, :name) do |point_card| %>
+      <%= point_card.label { point_card.check_box + point_card.text } %>
+    <% end %>
+  </div>
   <hr>
   <% if metod.eql?('edit') %>
     <%= f.submit "更新" %>

--- a/app/views/web/search.html.erb
+++ b/app/views/web/search.html.erb
@@ -444,6 +444,16 @@
       <% end %>
     </div>
     
+    <div class="search-container">
+      <div class="search-name">お気に入り登録</div>
+      <div class="search-radio">
+        <%= f.radio_button :bookmark, :register %>
+        <%= f.label :bookmark, "登録済み", {value: :register, style: "display: inline-block;"} %>
+        <%= f.radio_button :bookmark, :unregistered %>
+        <%= f.label :bookmark, "未登録", {value: :unregistered, style: "display: inline-block;"} %>
+      </div>
+    </div>
+    
     <hr>
     <%= f.submit :search, :class => 'btn-search' %>
   <% end %> 

--- a/app/views/web/search.html.erb
+++ b/app/views/web/search.html.erb
@@ -384,6 +384,66 @@
       <% end %>
     </div>
     
+    <div class="search-container">
+      <div class="search-name">予約</div>
+      <%= f.collection_radio_buttons(:reservation, CoffeeShop.reservations_i18n, :first, :last, {include_hidden: false}) do |reservation| %>
+        <div class="search-radio">
+          <%= reservation.radio_button %>
+          <%= reservation.label %>
+        </div>
+      <% end %>
+    </div>
+    
+    <div class="search-container">
+      <div class="search-name">テイクアウト</div>
+      <%= f.collection_radio_buttons(:take_out, CoffeeShop.take_outs_i18n, :first, :last, {include_hidden: false}) do |take_out| %>
+        <div class="search-radio">
+          <%= take_out.radio_button %>
+          <%= take_out.label %>
+        </div>
+      <% end %>
+    </div>
+    
+    <div class="search-container">
+      <div class="search-name">お子様連れ</div>
+      <%= f.collection_radio_buttons(:with_children, CoffeeShop.with_children_i18n, :first, :last, {include_hidden: false}) do |with_children| %>
+        <div class="search-radio">
+          <%= with_children.radio_button %>
+          <%= with_children.label %>
+        </div>
+      <% end %>
+    </div>
+    
+    <div class="search-container">
+      <div class="search-name">Instagramアカウント</div>
+      <%= f.collection_radio_buttons(:have_insta_account, CoffeeShop.have_insta_accounts_i18n, :first, :last, {include_hidden: false}) do |have_insta_account| %>
+        <div class="search-radio">
+          <%= have_insta_account.radio_button %>
+          <%= have_insta_account.label %>
+        </div>
+      <% end %>
+    </div>
+    
+    <div class="search-container">
+      <div class="search-name">アミューズメント</div>
+      <%= f.collection_radio_buttons(:amusement, CoffeeShop.amusements_i18n, :first, :last, {include_hidden: false}) do |amusement| %>
+        <div class="search-radio">
+          <%= amusement.radio_button %>
+          <%= amusement.label %>
+        </div>
+      <% end %>
+    </div>
+    
+    <div class="search-container">
+      <div class="search-name">インスタ映え</div>
+      <%= f.collection_radio_buttons(:look_by_instagram, CoffeeShop.look_by_instagrams_i18n, :first, :last, {include_hidden: false}) do |look_by_instagram| %>
+        <div class="search-radio">
+          <%= look_by_instagram.radio_button %>
+          <%= look_by_instagram.label %>
+        </div>
+      <% end %>
+    </div>
+    
     <hr>
     <%= f.submit :search, :class => 'btn-search' %>
   <% end %> 

--- a/app/views/web/search.html.erb
+++ b/app/views/web/search.html.erb
@@ -374,6 +374,16 @@
       <% end %>
     </div>
     
+    <div class="search-container">
+      <div class="search-name">ポイントカード</div>
+      <%= f.collection_check_boxes(:point_card_ids, PointCard.all, :id, :name, {include_hidden: false}) do |point_card| %>
+        <div class="search-checkbox">
+          <%= point_card.check_box %>
+          <%= point_card.label %>
+        </div>
+      <% end %>
+    </div>
+    
     <hr>
     <%= f.submit :search, :class => 'btn-search' %>
   <% end %> 

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -12,3 +12,22 @@ ja:
         smoking: '喫煙可能'
         no_smoking: '禁煙'
         separate_smoke: '分煙'
+      reservation:
+        reservation_possible: '予約可'
+        reservations_not_accepted: '予約不可'
+      take_out:
+        available: 'あり'
+        not_available: 'なし'
+      with_children:
+        available: '子供可'
+        not_available: '子供不可'
+      have_insta_account:
+        have_account: 'あり'
+        not_have_account: 'なし'
+      amusement:
+        exist: 'あり'
+        not_exist: 'なし'
+      look_by_instagram:
+        exterior: '外観'
+        interior: '内装'
+        food: '食べ物'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,7 @@ Rails.application.routes.draw do
     resources :use_scenes, except: [:new]
     resources :atmosphere_of_clerks, except: [:new]
     resources :size_of_desks, except: [:new]
+    resources :point_cards, except: [:new]
   end
   
   devise_for :users, :controllers => {

--- a/db/migrate/20220109064835_create_point_cards.rb
+++ b/db/migrate/20220109064835_create_point_cards.rb
@@ -1,0 +1,9 @@
+class CreatePointCards < ActiveRecord::Migration[5.2]
+  def change
+    create_table :point_cards do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220109064850_create_coffee_shop_point_cards.rb
+++ b/db/migrate/20220109064850_create_coffee_shop_point_cards.rb
@@ -1,0 +1,10 @@
+class CreateCoffeeShopPointCards < ActiveRecord::Migration[5.2]
+  def change
+    create_table :coffee_shop_point_cards do |t|
+      t.integer :coffee_shop_id
+      t.integer :point_card_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220109083516_add_reserve.rb
+++ b/db/migrate/20220109083516_add_reserve.rb
@@ -1,0 +1,5 @@
+class AddReserve < ActiveRecord::Migration[5.2]
+  def change
+    add_column :coffee_shops, :reservation, :integer
+  end
+end

--- a/db/migrate/20220109084321_addtakeout.rb
+++ b/db/migrate/20220109084321_addtakeout.rb
@@ -1,0 +1,9 @@
+class Addtakeout < ActiveRecord::Migration[5.2]
+  def change
+    add_column :coffee_shops, :take_out, :integer
+    add_column :coffee_shops, :with_children, :integer
+    add_column :coffee_shops, :have_insta_account, :integer
+    add_column :coffee_shops, :amusement, :integer
+    add_column :coffee_shops, :look_by_instagram, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_09_064850) do
+ActiveRecord::Schema.define(version: 2022_01_09_084321) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -192,6 +192,12 @@ ActiveRecord::Schema.define(version: 2022_01_09_064850) do
     t.integer "outlet"
     t.integer "wifi"
     t.integer "smoking"
+    t.integer "reservation"
+    t.integer "take_out"
+    t.integer "with_children"
+    t.integer "have_insta_account"
+    t.integer "amusement"
+    t.integer "look_by_instagram"
   end
 
   create_table "day_of_weeks", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_09_043253) do
+ActiveRecord::Schema.define(version: 2022_01_09_064850) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -88,6 +88,13 @@ ActiveRecord::Schema.define(version: 2022_01_09_043253) do
   create_table "coffee_shop_payment_methods", force: :cascade do |t|
     t.integer "coffee_shop_id"
     t.integer "payment_method_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "coffee_shop_point_cards", force: :cascade do |t|
+    t.integer "coffee_shop_id"
+    t.integer "point_card_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
@@ -243,6 +250,12 @@ ActiveRecord::Schema.define(version: 2022_01_09_043253) do
   end
 
   create_table "pc_works", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "point_cards", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/test/fixtures/coffee_shop_point_cards.yml
+++ b/test/fixtures/coffee_shop_point_cards.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/point_cards.yml
+++ b/test/fixtures/point_cards.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/coffee_shop_point_card_test.rb
+++ b/test/models/coffee_shop_point_card_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class CoffeeShopPointCardTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/point_card_test.rb
+++ b/test/models/point_card_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class PointCardTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# 背景
- この機能が必要な理由
使いたいポイントカードで店舗の検索ができるようにするため

- どういう機能なのか
ポイントカードから店舗の検索ができる
店舗情報にポイントカードが表示されている

- なぜこのPR単位なのか
ポイントカードでまとめるため
他にも2択で作成できる簡単な検索項目を作成

# やったこと
## コードベース
- 設計方針
ポイントカードは今後増えたり減ったりする可能性があるため、
専用のテーブルを作成し、中間テーブルを用いて、
店舗情報と紐づける

- model
他の中間テーブルと同じため省略

- controller
他の中間テーブルと同じため省略

- view
他の中間テーブルと同じため省略

# 画面レイアウト
- ポイントカード一覧画面
![image](https://user-images.githubusercontent.com/87374457/148724727-86ef7529-2d46-40d3-b50b-de0cd7960516.png)

- 検索画面
![image](https://user-images.githubusercontent.com/87374457/148724743-988b910b-1c34-4d37-8919-c7e7f312a93b.png)

- 店舗情報詳細画面
![image](https://user-images.githubusercontent.com/87374457/148724772-f47fdebd-19c3-43bb-aba1-7f60cc6f2e39.png)

# 検証内容
- [x] ポイントカードの登録ができるか
- [x] ポイントカードの編集ができるか
- [x] ポイントカードの削除ができるか
- [x] 店舗情報にポイントカードを登録できるか
- [x] 店舗情報に登録されているポイントカードは変更できるか
- [x] ポイントカードは検索画面に表示されているか
- [x] ポイントカードから店舗の検索ができるか
- [x] 店舗詳細にポイントカードは表示されているか