### PR TITLE
電話番号に非公開を追加

### DIFF
--- a/app/controllers/dashboard/coffee_shops_controller.rb
+++ b/app/controllers/dashboard/coffee_shops_controller.rb
@@ -1,6 +1,7 @@
 class Dashboard::CoffeeShopsController < ApplicationController
   before_action :set_coffee_shop, only: %w[show edit update destroy]
   before_action :check_user_authority, only: :destroy
+  
   layout "dashboard/dashboard"
   PER = 15
   
@@ -66,7 +67,7 @@ class Dashboard::CoffeeShopsController < ApplicationController
   end
   
   def coffee_shop_params
-    params.require(:coffee_shop).permit(:name, :shop_url, :address, :shop_tell, :access, :business_start_hour, :business_end_hour, :instagram_url, :instagram_spot_url, :municipalitie_id, :slack_time_start, :slack_time_end, :age_group, :shop_seats, :pc_work, :time_limit, :terrace_seat, :can_reserved, :comic, :magazine, :latte_art, :newspaper, :morning_menu, :parking_place, :free_water, :with_pet, :free_pc, :shop_badget_upper, :shop_badget_lower, :coffee_price, :latte_price, :outlet, :wifi, :smoking, :reservation, :take_out, :with_children, :have_insta_account, :amusement, :look_by_instagram, 
+    params.require(:coffee_shop).permit(:name, :shop_url, :address, :shop_tell, :access, :business_start_hour, :business_end_hour, :instagram_url, :instagram_spot_url, :municipalitie_id, :slack_time_start, :slack_time_end, :age_group, :shop_seats, :pc_work, :time_limit, :terrace_seat, :can_reserved, :comic, :magazine, :latte_art, :newspaper, :morning_menu, :parking_place, :free_water, :with_pet, :free_pc, :shop_badget_upper, :shop_badget_lower, :coffee_price, :latte_price, :outlet, :wifi, :smoking, :reservation, :take_out, :with_children, :have_insta_account, :amusement, :look_by_instagram, :tell_secret, 
     { :search_category_ids => [], :shop_atmosphere_ids => [], :coffee_bean_ids => [], :volume_in_shop_ids => [], :food_menu_ids => [], :shop_bgm_ids => [], :shop_scenery_ids => [], :payment_method_ids => [], :chair_type_ids => [], :use_scene_ids => [], :atmosphere_of_clerk_ids => [], :size_of_desk_ids => [], :point_card_ids => [] }, images: [])
   end
   

--- a/app/models/coffee_shop.rb
+++ b/app/models/coffee_shop.rb
@@ -61,24 +61,6 @@ class CoffeeShop < ApplicationRecord
 	validates :name, :address, :municipalitie_id, :regular_holiday, presence: true
 	
 	# 電話番号チェック
-	# with_options if: :tell_secret? do |tell_secret|
-	# 	binding.pry
-	# 	tell_secret.validates :shop_tell, presence: true, format: { with: /\A\d{10,11}\z/ }
-	# 	tell_secret.validates :shop_tell, presence: true
-	# 	tell_secret.validates :shop_tell, uniqueness: true
-	# end
-
-	# def tell_secret?
-	# 	tell_secret == "false"
-	# end
-	# binding.pry
-	# validates :shop_tell, presence: true, format: { with: /\A\d{10,11}\z/ }, if: :tell_secret?
-	# validates :shop_tell, presence: true, if: :tell_secret?
-	# validates :shop_tell, uniqueness: true, if: :tell_secret?
-	
-	# def tell_secret?
-	# 	tell_secret == "false"
-	# end
 	validate :shop_tell_secret
 	
 	# 文字数

--- a/app/models/coffee_shop.rb
+++ b/app/models/coffee_shop.rb
@@ -58,13 +58,28 @@ class CoffeeShop < ApplicationRecord
 	
 	# バリデーション
 	# 必ず登録してほしい項目
-	validates :name, :address, :shop_tell, :municipalitie_id, :regular_holiday, presence: true
-	
-	# 重複チェック
-	validates :shop_tell, uniqueness: true
+	validates :name, :address, :municipalitie_id, :regular_holiday, presence: true
 	
 	# 電話番号チェック
-	validates :shop_tell, presence: true, format: { with: /\A\d{10,11}\z/ }
+	# with_options if: :tell_secret? do |tell_secret|
+	# 	binding.pry
+	# 	tell_secret.validates :shop_tell, presence: true, format: { with: /\A\d{10,11}\z/ }
+	# 	tell_secret.validates :shop_tell, presence: true
+	# 	tell_secret.validates :shop_tell, uniqueness: true
+	# end
+
+	# def tell_secret?
+	# 	tell_secret == "false"
+	# end
+	# binding.pry
+	# validates :shop_tell, presence: true, format: { with: /\A\d{10,11}\z/ }, if: :tell_secret?
+	# validates :shop_tell, presence: true, if: :tell_secret?
+	# validates :shop_tell, uniqueness: true, if: :tell_secret?
+	
+	# def tell_secret?
+	# 	tell_secret == "false"
+	# end
+	validate :shop_tell_secret
 	
 	# 文字数
 	validates :name, length: { maximum: 30 }
@@ -143,4 +158,15 @@ class CoffeeShop < ApplicationRecord
 		end
 	end
 	
+	def shop_tell_secret
+		return if tell_secret
+		if shop_tell.length < 10 or shop_tell.length > 11
+			errors.add(:shop_tell, "の桁数が不正です")
+		end
+		
+		if CoffeeShop.where(shop_tell: shop_tell).count == 1
+			errors.add(:shop_tell, "が使用済みです")
+		end
+	end
+
 end

--- a/app/service/coffee_shop_show_info_service.rb
+++ b/app/service/coffee_shop_show_info_service.rb
@@ -56,11 +56,14 @@ class CoffeeShopShowInfoService
   # 電話番号に「-」をつける
   def create_tell_number
     tell =  @coffee_shop.shop_tell
+    
     @shop_tell = ""
-    if tell.length == 10
-      @shop_tell << "#{tell[0,2]}-#{tell[2,4]}-#{tell[6,4]}"
+    if @coffee_shop.tell_secret
+      @shop_tell = "非公開"
+    elsif tell.length == 10
+      @shop_tell = "#{tell[0,2]}-#{tell[2,4]}-#{tell[6,4]}"
     elsif tell.length == 11
-      @shop_tell << "#{tell[0,3]}-#{tell[3,4]}-#{tell[7,4]}"
+      @shop_tell = "#{tell[0,3]}-#{tell[3,4]}-#{tell[7,4]}"
     end
   end
   

--- a/app/views/dashboard/coffee_shops/index.html.erb
+++ b/app/views/dashboard/coffee_shops/index.html.erb
@@ -28,7 +28,7 @@
           <%= render partial: 'shared/show_images', locals: { target: coffee_shop, image_size: "100x100" } %>
           </td>
           <td><%= coffee_shop.name %></td>
-          <td><%= coffee_shop.shop_tell %></td>
+          <td><%= CoffeeShopShowInfoService.new(coffee_shop).create_tell_number %></td>
           <td><%= coffee_shop.address %></td>
           <td><%= link_to "編集", edit_dashboard_coffee_shop_path(coffee_shop) %></td>
           <td><%= link_to "削除", dashboard_coffee_shop_path(coffee_shop), method: :delete, data: { confirm: 'Are you sure?' } %></td>

--- a/app/views/shared/dashboard/_shop_info.html.erb
+++ b/app/views/shared/dashboard/_shop_info.html.erb
@@ -7,6 +7,7 @@
   住所[必須]<%= f.text_field :address %>
   <br>
   電話番号[必須]<%= f.number_field :shop_tell %>
+  非公開<%= f.check_box :tell_secret, {}, "true", "false" %>
   <br>
   アクセス<%= f.text_field :access %>
   <br>

--- a/db/migrate/20220208110634_addtellsecret.rb
+++ b/db/migrate/20220208110634_addtellsecret.rb
@@ -1,0 +1,5 @@
+class Addtellsecret < ActiveRecord::Migration[5.2]
+  def change
+    add_column :coffee_shops, :tell_secret, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_09_084321) do
+ActiveRecord::Schema.define(version: 2022_02_08_110634) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -198,6 +198,7 @@ ActiveRecord::Schema.define(version: 2022_01_09_084321) do
     t.integer "have_insta_account"
     t.integer "amusement"
     t.integer "look_by_instagram"
+    t.boolean "tell_secret"
   end
 
   create_table "day_of_weeks", force: :cascade do |t|


### PR DESCRIPTION
# 背景
- この機能が必要な理由
電話番号が非公開の店舗が登録できなかったため

- どういう機能なのか
電話番号は非公開で登録できるようにし、
電話番号がなくても登録できるようにする
非公開で登録した店舗情報の電話番号は「非公開」で表示される

- なぜこのPR単位なのか
電話番号非公開でまとめるため

# やったこと
## コードベース
- 設計方針
coffee_shopテーブルに、電話番号が非公開かどうかのフラグを登録できるカラムを追加し、
そのフラグがTrueなら非公開として登録するようにする
非公開でも電話番号を登録できる場合があるため、新たにカラムを作成する
電話番号表示の際は、「-」を含める処理に追加する

- model
表示する電話番号を作成するためのサービスモデルに非公開の場合も追加
非公開かどうかでバリデーションの内容がことなるので、
カスタムバリデーションを作成
（条件付きバリデーションをしたかったけど、おそらく対応していないので断念）

- controller
特に変更なし

- view
店舗入力画面に非公開を選択するためのチェックボックスを追加

# 画面レイアウト
- 店舗情報登録
![image](https://user-images.githubusercontent.com/87374457/153191413-c9fba769-3dbc-442b-b39f-3f21c813bd4a.png)

- 店舗詳細表示
![image](https://user-images.githubusercontent.com/87374457/153191482-1b82d2c7-5d0d-45fd-955b-1b8a260f5707.png)

- お気に入り店舗の表示
![image](https://user-images.githubusercontent.com/87374457/153191518-c6fc86fb-6670-4f4e-baed-166f0940ab0c.png)

# 検証内容
- [x] 店舗情報に電話番号非公開を登録できるか
- [x] 店舗情報の電話番号非公開は解除できるか
- [x] 非公開を選択しながら、電話番号も入力できるか
- [x] 非公開を選択した場合、電話番号がどんな値でも登録できるか
- [x] 非公開を選択した店舗を店舗詳細画面に表示したさい電話番号は「非公開」で表示されているか
- [x] お気に入り店舗一覧で、電話番号非公開の店舗は電話番号が「非公開」で表示されているか