### PR TITLE
店舗情報登録方法をラジオボタンに変更

### DIFF
--- a/app/assets/stylesheets/dashboard.scss
+++ b/app/assets/stylesheets/dashboard.scss
@@ -1,3 +1,7 @@
 // Place all the styles related to the dashboard controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
+.dashbord-item {
+  font-size: 1rem;
+  font-weight: bold;
+}

--- a/app/assets/stylesheets/dashboard.scss
+++ b/app/assets/stylesheets/dashboard.scss
@@ -1,6 +1,3 @@
-// Place all the styles related to the dashboard controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: http://sass-lang.com/
 .dashbord-item {
   font-size: 1rem;
   font-weight: bold;

--- a/app/controllers/dashboard/coffee_shops_controller.rb
+++ b/app/controllers/dashboard/coffee_shops_controller.rb
@@ -18,7 +18,6 @@ class Dashboard::CoffeeShopsController < ApplicationController
   
   def new
     @coffee_shop = CoffeeShop.new
-    # set_municipality_tags
   end
 
   def create
@@ -57,14 +56,6 @@ class Dashboard::CoffeeShopsController < ApplicationController
   def set_coffee_shop
     @coffee_shop = CoffeeShop.find(params[:id])
   end
-    
-  # def set_municipality_tags
-  #   municipalities = Municipality.all
-  #   @municipality_tags = []
-  #   municipalities.each do |municipality|
-  #     @municipality_tags << [municipality.name, municipality.id]
-  #   end
-  # end
   
   def coffee_shop_params
     params.require(:coffee_shop).permit(:name, :shop_url, :address, :shop_tell, :access, :business_start_hour, :business_end_hour, :instagram_url, :instagram_spot_url, :municipalitie_id, :slack_time_start, :slack_time_end, :age_group, :shop_seats, :pc_work, :time_limit, :terrace_seat, :can_reserved, :comic, :magazine, :latte_art, :newspaper, :morning_menu, :parking_place, :free_water, :with_pet, :free_pc, :shop_badget_upper, :shop_badget_lower, :coffee_price, :latte_price, :outlet, :wifi, :smoking, :reservation, :take_out, :with_children, :have_insta_account, :amusement, :look_by_instagram, :tell_secret, 

--- a/app/controllers/dashboard/coffee_shops_controller.rb
+++ b/app/controllers/dashboard/coffee_shops_controller.rb
@@ -18,7 +18,7 @@ class Dashboard::CoffeeShopsController < ApplicationController
   
   def new
     @coffee_shop = CoffeeShop.new
-    set_municipality_tags
+    # set_municipality_tags
   end
 
   def create
@@ -32,7 +32,7 @@ class Dashboard::CoffeeShopsController < ApplicationController
   end
 
   def edit
-    set_municipality_tags
+    # set_municipality_tags
   end
 
   def update
@@ -58,13 +58,13 @@ class Dashboard::CoffeeShopsController < ApplicationController
     @coffee_shop = CoffeeShop.find(params[:id])
   end
     
-  def set_municipality_tags
-    municipalities = Municipality.all
-    @municipality_tags = []
-    municipalities.each do |municipality|
-      @municipality_tags << [municipality.name, municipality.id]
-    end
-  end
+  # def set_municipality_tags
+  #   municipalities = Municipality.all
+  #   @municipality_tags = []
+  #   municipalities.each do |municipality|
+  #     @municipality_tags << [municipality.name, municipality.id]
+  #   end
+  # end
   
   def coffee_shop_params
     params.require(:coffee_shop).permit(:name, :shop_url, :address, :shop_tell, :access, :business_start_hour, :business_end_hour, :instagram_url, :instagram_spot_url, :municipalitie_id, :slack_time_start, :slack_time_end, :age_group, :shop_seats, :pc_work, :time_limit, :terrace_seat, :can_reserved, :comic, :magazine, :latte_art, :newspaper, :morning_menu, :parking_place, :free_water, :with_pet, :free_pc, :shop_badget_upper, :shop_badget_lower, :coffee_price, :latte_price, :outlet, :wifi, :smoking, :reservation, :take_out, :with_children, :have_insta_account, :amusement, :look_by_instagram, :tell_secret, 

--- a/app/views/shared/dashboard/_shop_info.html.erb
+++ b/app/views/shared/dashboard/_shop_info.html.erb
@@ -1,19 +1,26 @@
 <%= form_with model: @coffee_shop, url: coffee_shop_url, local: true do |f| %>
 
+  <div class="form-inline mt-4 mb-4 row">
+    <%= f.label "画像" %>
+    <%= render partial: 'shared/show_images', locals: { target: @coffee_shop, image_size: "100x100" } %>
+    <div class="d-flex flex-column ml-2">
+      <small class="mb-3">600px×600px推奨。<br>画像をアップロードして下さい。</small>
+      <%= f.file_field :images, onChange: "javascript: handleImage(this.files);", multiple: true %>
+      <img id="image-preview",size="50x50">
+    </div>
+  </div>
   店舗名[必須]<%= f.text_field :name %>
-  <br>
-  店舗HP<%= f.text_field :shop_url %>
-  <br>
-  住所[必須]<%= f.text_field :address %>
   <br>
   電話番号[必須]<%= f.number_field :shop_tell %>
   非公開<%= f.check_box :tell_secret, {}, "true", "false" %>
   <br>
-  アクセス<%= f.text_field :access %>
+  住所[必須]<%= f.text_field :address %>
   <br>
-  営業時間<%= f.time_field :business_start_hour %> ~ <%= f.time_field :business_end_hour %>
-  <br>
-  すいている時間<%= f.time_field :slack_time_start %> ~ <%= f.time_field :slack_time_end %>
+  エリア[必須]
+  <% Municipality.all.each do |municipalitie| %>
+    <%= f.radio_button :municipalitie, municipalitie.id %>
+    <%= f.label :municipalitie, municipalitie.name, {value: municipalitie.id, stylr: "display: inline-block;"} %>
+  <% end %>
   <br>
   定休日[必須]
   <% DayOfWeek.all.each do |day_of_week| %>
@@ -24,24 +31,22 @@
     <% end %>
   <% end %>
   <br>
-  年齢層
-  <%= f.select :age_group, AgeGroup.pluck(:name), { include_blank: '選択してください' } %>
+  店舗HP<%= f.text_field :shop_url %>
   <br>
   Instagram公式URL<%= f.text_field :instagram_url %>
   <br>
-  InstagramスポットURL<%= f.text_field :instagram_spot_url %>
+  アクセス<%= f.text_field :access %>
   <br>
-  エリア[必須]<%= f.select :municipalitie_id, @municipality_tags, { include_blank: '選択してください' } %>
+  営業時間<%= f.time_field :business_start_hour %> ~ <%= f.time_field :business_end_hour %>
   <br>
-  <div class="form-inline mt-4 mb-4 row">
-    <%= f.label "画像" %>
-    <%= render partial: 'shared/show_images', locals: { target: @coffee_shop, image_size: "100x100" } %>
-    <div class="d-flex flex-column ml-2">
-      <small class="mb-3">600px×600px推奨。<br>画像をアップロードして下さい。</small>
-      <%= f.file_field :images, onChange: "javascript: handleImage(this.files);", multiple: true %>
-      <img id="image-preview",size="50x50">
-    </div>
-  </div>
+  すいている時間<%= f.time_field :slack_time_start %> ~ <%= f.time_field :slack_time_end %>
+  <br>
+  年齢層
+  <% AgeGroup.all.each do |age_group| %>
+    <%= f.radio_button :age_group, age_group.id %>
+    <%= f.label :age_group, age_group.name, {value: age_group.id, stylr: "display: inline-block;"} %>
+  <% end %>
+  <br>
   こだわり<br>
   <div class="check_box">
     <%= f.collection_check_boxes(:search_category_ids, SearchCategory.all, :id, :name) do |search_category| %>
@@ -54,6 +59,26 @@
       <%= shop_atmosphere.label { shop_atmosphere.check_box + shop_atmosphere.text } %>
     <% end %>
   </div>
+  店員さんの雰囲気<br>
+  <div class="check_box">
+    <%= f.collection_check_boxes(:atmosphere_of_clerk_ids, AtmosphereOfClerk.all, :id, :name) do |atmosphere_of_clerk| %>
+      <%= atmosphere_of_clerk.label { atmosphere_of_clerk.check_box + atmosphere_of_clerk.text } %>
+    <% end %>
+  </div>
+  静かさ<br>
+  <div class="check_box">
+    <%= f.collection_check_boxes(:volume_in_shop_ids, VolumeInShop.all, :id, :name) do |volume_in_shop| %>
+      <%= volume_in_shop.label { volume_in_shop.check_box + volume_in_shop.text } %>
+    <% end %>  
+  </div>
+  風景<br>
+  <div class="check_box">
+    <%= f.collection_check_boxes(:shop_scenery_ids, ShopScenery.all, :id, :name) do |shop_scenery| %>
+      <%= shop_scenery.label { shop_scenery.check_box + shop_scenery.text } %>
+    <% end %>
+  </div>
+  <br>
+  インスタ映え：<%= f.collection_radio_buttons :look_by_instagram, CoffeeShop.look_by_instagrams_i18n, :first , :last %>
   コーヒー豆<br>
   <div class="check_box">
     <%= f.collection_check_boxes(:coffee_bean_ids, CoffeeBean.all, :id, :name) do |coffee_bean| %>
@@ -62,12 +87,6 @@
   </div>
   席数<%= f.number_field :shop_seats %>
   <br>
-  静かさ<br>
-  <div class="check_box">
-    <%= f.collection_check_boxes(:volume_in_shop_ids, VolumeInShop.all, :id, :name) do |volume_in_shop| %>
-      <%= volume_in_shop.label { volume_in_shop.check_box + volume_in_shop.text } %>
-    <% end %>  
-  </div>
   食べもの<br>
   <div class="check_box">
     <%= f.collection_check_boxes(:food_menu_ids, FoodMenu.all, :id, :name) do |food_menu| %>
@@ -80,42 +99,76 @@
       <%= shop_bgm.label { shop_bgm.check_box + shop_bgm.text } %>
     <% end %>
   </div>
-  PC作業<%= f.select :pc_work, PcWork.pluck(:name), { include_blank: '選択してください' } %>
+  テラス席
+  <%= f.radio_button :terrace_seat, 'あり' %>
+  <%= f.label :terrace_seat, 'あり', {value: 'あり', stylr: "display: inline-block;"} %>
+  <%= f.radio_button :terrace_seat, 'なし' %>
+  <%= f.label :terrace_seat, 'なし', {value: 'なし', stylr: "display: inline-block;"} %>
   <br>
-  時間制限<%= f.select :time_limit, TimeLimit.pluck(:name), { include_blank: '選択してください' } %>
+  貸切
+  <%= f.radio_button :can_reserved, '可' %>
+  <%= f.label :can_reserved, '可', {value: '可', stylr: "display: inline-block;"} %>
+  <%= f.radio_button :can_reserved, '不可' %>
+  <%= f.label :can_reserved, '不可', {value: '不可', stylr: "display: inline-block;"} %>
   <br>
-  風景<br>
-  <div class="check_box">
-    <%= f.collection_check_boxes(:shop_scenery_ids, ShopScenery.all, :id, :name) do |shop_scenery| %>
-      <%= shop_scenery.label { shop_scenery.check_box + shop_scenery.text } %>
-    <% end %>
-  </div>
-  テラス席<%= f.select :terrace_seat, ['あり', 'なし'], { include_blank: '選択してください'} %>
+  漫画
+  <%= f.radio_button :comic, 'あり' %>
+  <%= f.label :comic, 'あり', {value: 'あり', stylr: "display: inline-block;"} %>
+  <%= f.radio_button :comic, 'なし' %>
+  <%= f.label :comic, 'なし', {value: 'なし', stylr: "display: inline-block;"} %>
   <br>
-  貸切<%= f.select :can_reserved, ['可','不可'], { include_blank: '選択してください'} %>
+  雑誌
+  <%= f.radio_button :magazine, 'あり' %>
+  <%= f.label :magazine, 'あり', {value: 'あり', stylr: "display: inline-block;"} %>
+  <%= f.radio_button :magazine, 'なし' %>
+  <%= f.label :magazine, 'なし', {value: 'なし', stylr: "display: inline-block;"} %>
   <br>
-  漫画<%= f.select :comic, ['あり','なし'], { include_blank: '選択してください' } %>
+  新聞
+  <%= f.radio_button :newspaper, 'あり' %>
+  <%= f.label :newspaper, 'あり', {value: 'あり', stylr: "display: inline-block;"} %>
+  <%= f.radio_button :newspaper, 'なし' %>
+  <%= f.label :newspaper, 'なし', {value: 'なし', stylr: "display: inline-block;"} %>
   <br>
-  雑誌<%= f.select :magazine, ['あり','なし'], { include_blank: '選択してください' } %>
+  ラテアート
+  <%= f.radio_button :latte_art, 'あり' %>
+  <%= f.label :latte_art, 'あり', {value: 'あり', stylr: "display: inline-block;"} %>
+  <%= f.radio_button :latte_art, 'なし' %>
+  <%= f.label :latte_art, 'なし', {value: 'なし', stylr: "display: inline-block;"} %>
   <br>
-  ラテアート<%= f.select :latte_art, ['あり','なし'], { include_blank: '選択してください' } %>
+  モーニング
+  <%= f.radio_button :morning_menu, 'あり' %>
+  <%= f.label :morning_menu, 'あり', {value: 'あり', stylr: "display: inline-block;"} %>
+  <%= f.radio_button :morning_menu, 'なし' %>
+  <%= f.label :morning_menu, 'なし', {value: 'なし', stylr: "display: inline-block;"} %>
   <br>
-  新聞<%= f.select :newspaper, ['あり','なし'], { include_blank: '選択してください' } %>
+  無料の水
+  <%= f.radio_button :free_water, 'あり' %>
+  <%= f.label :free_water, 'あり', {value: 'あり', stylr: "display: inline-block;"} %>
+  <%= f.radio_button :free_water, 'なし' %>
+  <%= f.label :free_water, 'なし', {value: 'なし', stylr: "display: inline-block;"} %>
   <br>
-  モーニング<%= f.select :morning_menu, ['あり','なし'], { include_blank: '選択してください' } %>
+  ペット
+  <%= f.radio_button :with_pet, 'あり' %>
+  <%= f.label :with_pet, 'あり', {value: 'あり', stylr: "display: inline-block;"} %>
+  <%= f.radio_button :with_pet, 'なし' %>
+  <%= f.label :with_pet, 'なし', {value: 'なし', stylr: "display: inline-block;"} %>
   <br>
-  無料の水<%= f.select :free_water, ['あり','なし'], { include_blank: '選択してください' } %>
-  <br>
-  ペット<%= f.select :with_pet, ['可','不可'], { include_blank: '選択してください' } %>
-  <br>
-  共有PC<%= f.select :free_pc, ['あり','なし'], { include_blank: '選択してください' } %>
-  <br>
-  駐車場<%= f.select :parking_place, ['あり', 'なし'], { include_blank: '選択してください' } %>
+  駐車場
+  <%= f.radio_button :parking_place, 'あり' %>
+  <%= f.label :parking_place, 'あり', {value: 'あり', stylr: "display: inline-block;"} %>
+  <%= f.radio_button :parking_place, 'なし' %>
+  <%= f.label :parking_place, 'なし', {value: 'なし', stylr: "display: inline-block;"} %>
   <br>
   支払い方法<br>
   <div class="check_box">
     <%= f.collection_check_boxes(:payment_method_ids, PaymentMethod.all, :id, :name) do |payment_method| %>
       <%= payment_method.label { payment_method.check_box + payment_method.text } %>
+    <% end %>
+  </div>
+  ポイントカード<br>
+  <div class="check_box">
+    <%= f.collection_check_boxes(:point_card_ids, PointCard.all, :id, :name) do |point_card| %>
+      <%= point_card.label { point_card.check_box + point_card.text } %>
     <% end %>
   </div>
   予算(上限)：<%= f.number_field :shop_badget_upper %>円
@@ -126,17 +179,11 @@
   <br>
   カフェラテ(1杯)：<%= f.number_field :latte_price %>円
   <br>
-  椅子の種類<br>
-  <div class="check_box">
-    <%= f.collection_check_boxes(:chair_type_ids, ChairType.all, :id, :name) do |chair_type| %>
-      <%= chair_type.label { chair_type.check_box + chair_type.text } %>
-    <% end %>
-  </div>
-  コンセント：<%= f.select :outlet, CoffeeShop.outlets_i18n.invert, { include_blank: '選択してください'} %>
+  コンセント：<%= f.collection_radio_buttons :outlet, CoffeeShop.outlets_i18n, :first , :last %>
   <br>
-  Wi-Fi：<%= f.select :wifi, CoffeeShop.wifis_i18n.invert, { include_blank: '選択してください'} %>
+  Wi-Fi：<%= f.collection_radio_buttons :wifi, CoffeeShop.wifis_i18n, :first , :last %>
   <br>
-  禁煙・喫煙：<%= f.select :smoking, CoffeeShop.smokings_i18n.invert, { include_blank: '選択してください'} %>
+  禁煙・喫煙：<%= f.collection_radio_buttons :smoking, CoffeeShop.smokings_i18n, :first , :last %>
   <br>
   利用シーン<br>
   <div class="check_box">
@@ -144,10 +191,28 @@
       <%= use_scene.label { use_scene.check_box + use_scene.text } %>
     <% end %>
   </div>
-  店員さんの雰囲気<br>
+  PC作業
+  <% PcWork.all.each do |pc_work| %>
+    <%= f.radio_button :pc_work, pc_work.id %>
+    <%= f.label :pc_work, pc_work.name, {value: pc_work.id, stylr: "display: inline-block;"} %>
+  <% end %>
+  <br>
+  時間制限
+  <% TimeLimit.all.each do |time_limit| %>
+    <%= f.radio_button :time_limit, time_limit.id %>
+    <%= f.label :time_limit, time_limit.name, {value: time_limit.id, stylr: "display: inline-block;"} %>
+  <% end %>
+  <br>
+  共有PC
+  <%= f.radio_button :free_pc, 'あり' %>
+  <%= f.label :free_pc, 'あり', {value: 'あり', stylr: "display: inline-block;"} %>
+  <%= f.radio_button :free_pc, 'なし' %>
+  <%= f.label :free_pc, 'なし', {value: 'なし', stylr: "display: inline-block;"} %>
+  <br>
+  椅子の種類<br>
   <div class="check_box">
-    <%= f.collection_check_boxes(:atmosphere_of_clerk_ids, AtmosphereOfClerk.all, :id, :name) do |atmosphere_of_clerk| %>
-      <%= atmosphere_of_clerk.label { atmosphere_of_clerk.check_box + atmosphere_of_clerk.text } %>
+    <%= f.collection_check_boxes(:chair_type_ids, ChairType.all, :id, :name) do |chair_type| %>
+      <%= chair_type.label { chair_type.check_box + chair_type.text } %>
     <% end %>
   </div>
   机の広さ<br>
@@ -156,21 +221,13 @@
       <%= size_of_desk.label { size_of_desk.check_box + size_of_desk.text } %>
     <% end %>
   </div>
-  ポイントカード<br>
-  <div class="check_box">
-    <%= f.collection_check_boxes(:point_card_ids, PointCard.all, :id, :name) do |point_card| %>
-      <%= point_card.label { point_card.check_box + point_card.text } %>
-    <% end %>
-  </div>
-  予約：<%= f.select :reservation, CoffeeShop.reservations_i18n.invert, { include_blank: '選択してください'} %>
+  予約：<%= f.collection_radio_buttons :reservation, CoffeeShop.reservations_i18n, :first , :last %>
   <br>
-  テイクアウト：<%= f.select :take_out, CoffeeShop.take_outs_i18n.invert, { include_blank: '選択してください'} %>
+  テイクアウト：<%= f.collection_radio_buttons :take_out, CoffeeShop.take_outs_i18n, :first , :last %>
   <br>
-  お子様連れ：<%= f.select :with_children, CoffeeShop.with_children_i18n.invert, { include_blank: '選択してください'} %>
+  お子様連れ：<%= f.collection_radio_buttons :with_children, CoffeeShop.with_children_i18n, :first , :last %>
   <br>
-  アミューズメント：<%= f.select :amusement, CoffeeShop.amusements_i18n.invert, { include_blank: '選択してください'} %>
-  <br>
-  インスタ映え：<%= f.select :look_by_instagram, CoffeeShop.look_by_instagrams_i18n.invert, { include_blank: '選択してください'} %>
+  アミューズメント：<%= f.collection_radio_buttons :amusement, CoffeeShop.amusements_i18n, :first , :last %>
   <hr>
   <% if metod.eql?('edit') %>
     <%= f.submit "更新" %>

--- a/app/views/shared/dashboard/_shop_info.html.erb
+++ b/app/views/shared/dashboard/_shop_info.html.erb
@@ -9,20 +9,19 @@
       <img id="image-preview",size="50x50">
     </div>
   </div>
-  店舗名[必須]<%= f.text_field :name %>
+  <div class='dashbord-item'>店舗名[必須]</div><%= f.text_field :name %>
   <br>
-  電話番号[必須]<%= f.number_field :shop_tell %>
-  非公開<%= f.check_box :tell_secret, {}, "true", "false" %>
+  <div class='dashbord-item'>電話番号[必須]</div><%= f.number_field :shop_tell %>非公開<%= f.check_box :tell_secret, {}, "true", "false" %>
   <br>
-  住所[必須]<%= f.text_field :address %>
+  <div class='dashbord-item'>住所[必須]</div><%= f.text_field :address %>
   <br>
-  エリア[必須]
+  <div class='dashbord-item'>エリア[必須]</div>
   <% Municipality.all.each do |municipalitie| %>
     <%= f.radio_button :municipalitie, municipalitie.id %>
     <%= f.label :municipalitie, municipalitie.name, {value: municipalitie.id, stylr: "display: inline-block;"} %>
   <% end %>
   <br>
-  定休日[必須]
+  <div class='dashbord-item'>定休日[必須]</div>
   <% DayOfWeek.all.each do |day_of_week| %>
     <% if metod.eql?('edit') %>
       <%= check_box_tag 'regular_holidays[]', day_of_week.name, @coffee_shop.regular_holiday.include?(day_of_week.name) %><%= day_of_week.name %>
@@ -31,203 +30,202 @@
     <% end %>
   <% end %>
   <br>
-  店舗HP<%= f.text_field :shop_url %>
+  <div class='dashbord-item'>店舗HP</div><%= f.text_field :shop_url %>
   <br>
-  Instagram公式URL<%= f.text_field :instagram_url %>
+  <div class='dashbord-item'>Instagram公式URL</div><%= f.text_field :instagram_url %>
   <br>
-  アクセス<%= f.text_field :access %>
+  <div class='dashbord-item'>アクセス</div><%= f.text_field :access %>
   <br>
-  営業時間<%= f.time_field :business_start_hour %> ~ <%= f.time_field :business_end_hour %>
+  <div class='dashbord-item'>営業時間</div><%= f.time_field :business_start_hour %> ~ <%= f.time_field :business_end_hour %>
   <br>
-  すいている時間<%= f.time_field :slack_time_start %> ~ <%= f.time_field :slack_time_end %>
+  <div class='dashbord-item'>すいている時間</div><%= f.time_field :slack_time_start %> ~ <%= f.time_field :slack_time_end %>
   <br>
-  年齢層
+  <div class='dashbord-item'>年齢層</div>
   <% AgeGroup.all.each do |age_group| %>
     <%= f.radio_button :age_group, age_group.id %>
     <%= f.label :age_group, age_group.name, {value: age_group.id, stylr: "display: inline-block;"} %>
   <% end %>
   <br>
-  こだわり<br>
+  <div class='dashbord-item'>こだわり</div>
   <div class="check_box">
     <%= f.collection_check_boxes(:search_category_ids, SearchCategory.all, :id, :name) do |search_category| %>
       <%= search_category.label { search_category.check_box + search_category.text } %>
     <% end %>
   </div>
-  お店の雰囲気<br>
+  <div class='dashbord-item'>お店の雰囲気</div>
   <div class="check_box">
     <%= f.collection_check_boxes(:shop_atmosphere_ids, ShopAtmosphere.all, :id, :name) do |shop_atmosphere| %>
       <%= shop_atmosphere.label { shop_atmosphere.check_box + shop_atmosphere.text } %>
     <% end %>
   </div>
-  店員さんの雰囲気<br>
+  <div class='dashbord-item'>店員さんの雰囲気</div>
   <div class="check_box">
     <%= f.collection_check_boxes(:atmosphere_of_clerk_ids, AtmosphereOfClerk.all, :id, :name) do |atmosphere_of_clerk| %>
       <%= atmosphere_of_clerk.label { atmosphere_of_clerk.check_box + atmosphere_of_clerk.text } %>
     <% end %>
   </div>
-  静かさ<br>
+  <div class='dashbord-item'>静かさ</div>
   <div class="check_box">
     <%= f.collection_check_boxes(:volume_in_shop_ids, VolumeInShop.all, :id, :name) do |volume_in_shop| %>
       <%= volume_in_shop.label { volume_in_shop.check_box + volume_in_shop.text } %>
     <% end %>  
   </div>
-  風景<br>
+  <div class='dashbord-item'>風景</div>
   <div class="check_box">
     <%= f.collection_check_boxes(:shop_scenery_ids, ShopScenery.all, :id, :name) do |shop_scenery| %>
       <%= shop_scenery.label { shop_scenery.check_box + shop_scenery.text } %>
     <% end %>
   </div>
-  <br>
-  インスタ映え：<%= f.collection_radio_buttons :look_by_instagram, CoffeeShop.look_by_instagrams_i18n, :first , :last %>
-  コーヒー豆<br>
+  <div class='dashbord-item'>インスタ映え</div><%= f.collection_radio_buttons :look_by_instagram, CoffeeShop.look_by_instagrams_i18n, :first , :last %>
+  <div class='dashbord-item'>コーヒー豆</div>
   <div class="check_box">
     <%= f.collection_check_boxes(:coffee_bean_ids, CoffeeBean.all, :id, :name) do |coffee_bean| %>
       <%= coffee_bean.label { coffee_bean.check_box + coffee_bean.text } %>
     <% end %>
   </div>
-  席数<%= f.number_field :shop_seats %>
+  <div class='dashbord-item'>席数</div><%= f.number_field :shop_seats %>
   <br>
-  食べもの<br>
+  <div class='dashbord-item'>食べもの</div>
   <div class="check_box">
     <%= f.collection_check_boxes(:food_menu_ids, FoodMenu.all, :id, :name) do |food_menu| %>
       <%= food_menu.label { food_menu.check_box + food_menu.text } %>
     <% end %>
   </div>
-  BGM<br>
+  <div class='dashbord-item'>BGM</div>
   <div class="check_box">
     <%= f.collection_check_boxes(:shop_bgm_ids, ShopBgm.all, :id, :name) do |shop_bgm| %>
       <%= shop_bgm.label { shop_bgm.check_box + shop_bgm.text } %>
     <% end %>
   </div>
-  テラス席
+  <div class='dashbord-item'>テラス席</div>
   <%= f.radio_button :terrace_seat, 'あり' %>
   <%= f.label :terrace_seat, 'あり', {value: 'あり', stylr: "display: inline-block;"} %>
   <%= f.radio_button :terrace_seat, 'なし' %>
   <%= f.label :terrace_seat, 'なし', {value: 'なし', stylr: "display: inline-block;"} %>
   <br>
-  貸切
+  <div class='dashbord-item'>貸切</div>
   <%= f.radio_button :can_reserved, '可' %>
   <%= f.label :can_reserved, '可', {value: '可', stylr: "display: inline-block;"} %>
   <%= f.radio_button :can_reserved, '不可' %>
   <%= f.label :can_reserved, '不可', {value: '不可', stylr: "display: inline-block;"} %>
   <br>
-  漫画
+  <div class='dashbord-item'>漫画</div>
   <%= f.radio_button :comic, 'あり' %>
   <%= f.label :comic, 'あり', {value: 'あり', stylr: "display: inline-block;"} %>
   <%= f.radio_button :comic, 'なし' %>
   <%= f.label :comic, 'なし', {value: 'なし', stylr: "display: inline-block;"} %>
   <br>
-  雑誌
+  <div class='dashbord-item'>雑誌</div>
   <%= f.radio_button :magazine, 'あり' %>
   <%= f.label :magazine, 'あり', {value: 'あり', stylr: "display: inline-block;"} %>
   <%= f.radio_button :magazine, 'なし' %>
   <%= f.label :magazine, 'なし', {value: 'なし', stylr: "display: inline-block;"} %>
   <br>
-  新聞
+  <div class='dashbord-item'>新聞</div>
   <%= f.radio_button :newspaper, 'あり' %>
   <%= f.label :newspaper, 'あり', {value: 'あり', stylr: "display: inline-block;"} %>
   <%= f.radio_button :newspaper, 'なし' %>
   <%= f.label :newspaper, 'なし', {value: 'なし', stylr: "display: inline-block;"} %>
   <br>
-  ラテアート
+  <div class='dashbord-item'>ラテアート</div>
   <%= f.radio_button :latte_art, 'あり' %>
   <%= f.label :latte_art, 'あり', {value: 'あり', stylr: "display: inline-block;"} %>
   <%= f.radio_button :latte_art, 'なし' %>
   <%= f.label :latte_art, 'なし', {value: 'なし', stylr: "display: inline-block;"} %>
   <br>
-  モーニング
+  <div class='dashbord-item'>モーニング</div>
   <%= f.radio_button :morning_menu, 'あり' %>
   <%= f.label :morning_menu, 'あり', {value: 'あり', stylr: "display: inline-block;"} %>
   <%= f.radio_button :morning_menu, 'なし' %>
   <%= f.label :morning_menu, 'なし', {value: 'なし', stylr: "display: inline-block;"} %>
   <br>
-  無料の水
+  <div class='dashbord-item'>無料の水</div>
   <%= f.radio_button :free_water, 'あり' %>
   <%= f.label :free_water, 'あり', {value: 'あり', stylr: "display: inline-block;"} %>
   <%= f.radio_button :free_water, 'なし' %>
   <%= f.label :free_water, 'なし', {value: 'なし', stylr: "display: inline-block;"} %>
   <br>
-  ペット
+  <div class='dashbord-item'>ペット</div>
   <%= f.radio_button :with_pet, 'あり' %>
   <%= f.label :with_pet, 'あり', {value: 'あり', stylr: "display: inline-block;"} %>
   <%= f.radio_button :with_pet, 'なし' %>
   <%= f.label :with_pet, 'なし', {value: 'なし', stylr: "display: inline-block;"} %>
   <br>
-  駐車場
+  <div class='dashbord-item'>駐車場</div>
   <%= f.radio_button :parking_place, 'あり' %>
   <%= f.label :parking_place, 'あり', {value: 'あり', stylr: "display: inline-block;"} %>
   <%= f.radio_button :parking_place, 'なし' %>
   <%= f.label :parking_place, 'なし', {value: 'なし', stylr: "display: inline-block;"} %>
   <br>
-  支払い方法<br>
+  <div class='dashbord-item'>支払い方法</div>
   <div class="check_box">
     <%= f.collection_check_boxes(:payment_method_ids, PaymentMethod.all, :id, :name) do |payment_method| %>
       <%= payment_method.label { payment_method.check_box + payment_method.text } %>
     <% end %>
   </div>
-  ポイントカード<br>
+  <div class='dashbord-item'>ポイントカード</div>
   <div class="check_box">
     <%= f.collection_check_boxes(:point_card_ids, PointCard.all, :id, :name) do |point_card| %>
       <%= point_card.label { point_card.check_box + point_card.text } %>
     <% end %>
   </div>
-  予算(上限)：<%= f.number_field :shop_badget_upper %>円
+  <div class='dashbord-item'>予算(上限)</div><%= f.number_field :shop_badget_upper %>円
   <br>
-  予算(下限)；<%= f.number_field :shop_badget_lower %>円
+  <div class='dashbord-item'>予算(下限)</div><%= f.number_field :shop_badget_lower %>円
   <br>
-  コーヒー(1杯)：<%= f.number_field :coffee_price %>円
+  <div class='dashbord-item'>コーヒー(1杯)</div><%= f.number_field :coffee_price %>円
   <br>
-  カフェラテ(1杯)：<%= f.number_field :latte_price %>円
+  <div class='dashbord-item'>カフェラテ(1杯)</div><%= f.number_field :latte_price %>円
   <br>
-  コンセント：<%= f.collection_radio_buttons :outlet, CoffeeShop.outlets_i18n, :first , :last %>
+  <div class='dashbord-item'>コンセント</div><%= f.collection_radio_buttons :outlet, CoffeeShop.outlets_i18n, :first , :last %>
   <br>
-  Wi-Fi：<%= f.collection_radio_buttons :wifi, CoffeeShop.wifis_i18n, :first , :last %>
+  <div class='dashbord-item'>Wi-Fi</div><%= f.collection_radio_buttons :wifi, CoffeeShop.wifis_i18n, :first , :last %>
   <br>
-  禁煙・喫煙：<%= f.collection_radio_buttons :smoking, CoffeeShop.smokings_i18n, :first , :last %>
+  <div class='dashbord-item'>禁煙・喫煙</div><%= f.collection_radio_buttons :smoking, CoffeeShop.smokings_i18n, :first , :last %>
   <br>
-  利用シーン<br>
+  <div class='dashbord-item'>利用シーン</div>
   <div class="check_box">
     <%= f.collection_check_boxes(:use_scene_ids, UseScene.all, :id, :name) do |use_scene| %>
       <%= use_scene.label { use_scene.check_box + use_scene.text } %>
     <% end %>
   </div>
-  PC作業
+  <div class='dashbord-item'>PC作業</div>
   <% PcWork.all.each do |pc_work| %>
     <%= f.radio_button :pc_work, pc_work.id %>
     <%= f.label :pc_work, pc_work.name, {value: pc_work.id, stylr: "display: inline-block;"} %>
   <% end %>
   <br>
-  時間制限
+  <div class='dashbord-item'>時間制限</div>
   <% TimeLimit.all.each do |time_limit| %>
     <%= f.radio_button :time_limit, time_limit.id %>
     <%= f.label :time_limit, time_limit.name, {value: time_limit.id, stylr: "display: inline-block;"} %>
   <% end %>
   <br>
-  共有PC
+  <div class='dashbord-item'>共有PC</div>
   <%= f.radio_button :free_pc, 'あり' %>
   <%= f.label :free_pc, 'あり', {value: 'あり', stylr: "display: inline-block;"} %>
   <%= f.radio_button :free_pc, 'なし' %>
   <%= f.label :free_pc, 'なし', {value: 'なし', stylr: "display: inline-block;"} %>
   <br>
-  椅子の種類<br>
+  <div class='dashbord-item'>椅子の種類</div>
   <div class="check_box">
     <%= f.collection_check_boxes(:chair_type_ids, ChairType.all, :id, :name) do |chair_type| %>
       <%= chair_type.label { chair_type.check_box + chair_type.text } %>
     <% end %>
   </div>
-  机の広さ<br>
+  <div class='dashbord-item'>机の広さ</div>
   <div class="check_box">
     <%= f.collection_check_boxes(:size_of_desk_ids, SizeOfDesk.all, :id, :name) do |size_of_desk| %>
       <%= size_of_desk.label { size_of_desk.check_box + size_of_desk.text } %>
     <% end %>
   </div>
-  予約：<%= f.collection_radio_buttons :reservation, CoffeeShop.reservations_i18n, :first , :last %>
+  <div class='dashbord-item'>予約</div><%= f.collection_radio_buttons :reservation, CoffeeShop.reservations_i18n, :first , :last %>
   <br>
-  テイクアウト：<%= f.collection_radio_buttons :take_out, CoffeeShop.take_outs_i18n, :first , :last %>
+  <div class='dashbord-item'>テイクアウト</div><%= f.collection_radio_buttons :take_out, CoffeeShop.take_outs_i18n, :first , :last %>
   <br>
-  お子様連れ：<%= f.collection_radio_buttons :with_children, CoffeeShop.with_children_i18n, :first , :last %>
+  <div class='dashbord-item'>お子様連れ</div><%= f.collection_radio_buttons :with_children, CoffeeShop.with_children_i18n, :first , :last %>
   <br>
-  アミューズメント：<%= f.collection_radio_buttons :amusement, CoffeeShop.amusements_i18n, :first , :last %>
+  <div class='dashbord-item'>アミューズメント</div><%= f.collection_radio_buttons :amusement, CoffeeShop.amusements_i18n, :first , :last %>
   <hr>
   <% if metod.eql?('edit') %>
     <%= f.submit "更新" %>
@@ -236,5 +234,5 @@
   <% end %>
   
 <% end %>
-
+<br>
 <%= link_to "一覧に戻る", dashboard_coffee_shops_path %>


### PR DESCRIPTION
- 関連issue
https://github.com/syota0402/cafe_de_niche/issues/56

# 背景
- この機能が必要な理由
店舗登録する際に選択肢がわからず、登録が手間であるため、
全て表示できるようにラジオボタンに変更する

- どういう機能なのか
セレクトボックスで選択していたところを、ラジオボタンに変更

- なぜこのPR単位なのか
ラジオボタン変更だけでまとめるため

# やったこと
## コードベース
- 設計方針
複数選択はできないようにラジオボタンを用いる

- model
変更点なし

- controller
変更点なし

- view
ラジオボタンに変更

# 画面レイアウト
- 店舗情報入力画面
![image](https://user-images.githubusercontent.com/87374457/154249970-fbd9e193-891b-4e50-9acf-f0dea8ebd562.png)

# 検証内容
- [x] 問題なく登録は行えるか
- [x] 選択肢は全て表示されているか