### PR TITLE
店舗情報登録の際にエリアを絞れるように変更

### DIFF
--- a/app/controllers/dashboard/coffee_shops_controller.rb
+++ b/app/controllers/dashboard/coffee_shops_controller.rb
@@ -18,6 +18,7 @@ class Dashboard::CoffeeShopsController < ApplicationController
   
   def new
     @coffee_shop = CoffeeShop.new
+    # 対象の都道府県のエリアのみ表示
     @municipalities = Municipality.where(prefecture_id: params[:prefecture_id])
   end
 
@@ -32,7 +33,8 @@ class Dashboard::CoffeeShopsController < ApplicationController
   end
 
   def edit
-    set_municipalities
+    # 対象の都道府県のエリアのみ表示
+    @municipalities = Municipality.where(prefecture_id: Municipality.find(@coffee_shop.municipalitie_id).prefecture_id)
   end
 
   def update
@@ -76,17 +78,6 @@ class Dashboard::CoffeeShopsController < ApplicationController
     users.each do |user|
       user.update(best_shop_id: "")
     end
-  end
-  
-  def set_municipalities
-    # 店舗情報からエリアidを取得
-    eria_id = @coffee_shop.municipalitie_id
-    
-    # エリアIDから都道府県のIDを取得
-    set_prefecture_id = Municipality.find(eria_id).prefecture_id
-    
-    # 都道府県のIDから対象の都道府県の全てのエリアIDを取得
-    @municipalities = Municipality.where(prefecture_id: set_prefecture_id)
   end
   
 end

--- a/app/controllers/dashboard/coffee_shops_controller.rb
+++ b/app/controllers/dashboard/coffee_shops_controller.rb
@@ -18,6 +18,7 @@ class Dashboard::CoffeeShopsController < ApplicationController
   
   def new
     @coffee_shop = CoffeeShop.new
+    @municipalities = Municipality.where(prefecture_id: params[:prefecture_id])
   end
 
   def create
@@ -31,7 +32,7 @@ class Dashboard::CoffeeShopsController < ApplicationController
   end
 
   def edit
-    # set_municipality_tags
+    set_municipalities
   end
 
   def update
@@ -75,6 +76,17 @@ class Dashboard::CoffeeShopsController < ApplicationController
     users.each do |user|
       user.update(best_shop_id: "")
     end
+  end
+  
+  def set_municipalities
+    # 店舗情報からエリアidを取得
+    eria_id = @coffee_shop.municipalitie_id
+    
+    # エリアIDから都道府県のIDを取得
+    set_prefecture_id = Municipality.find(eria_id).prefecture_id
+    
+    # 都道府県のIDから対象の都道府県の全てのエリアIDを取得
+    @municipalities = Municipality.where(prefecture_id: set_prefecture_id)
   end
   
 end

--- a/app/views/dashboard/coffee_shops/index.html.erb
+++ b/app/views/dashboard/coffee_shops/index.html.erb
@@ -8,7 +8,7 @@
   
   <div>合計<%= @total_count %>件</div>
   
-  <%= link_to "店舗追加", new_dashboard_coffee_shop_path %>
+  <%= link_to "店舗追加", select_dashboard_coffee_shops_path %>
   
   <table class="table mt-5">
     <thead>

--- a/app/views/dashboard/coffee_shops/select.html.erb
+++ b/app/views/dashboard/coffee_shops/select.html.erb
@@ -1,0 +1,6 @@
+ <h2>都道府県を選択</h2>
+<% Prefecture.all.each do |prefecture| %>
+  <%= link_to new_dashboard_coffee_shop_path(prefecture_id: prefecture.id) , class: "btn btn-prefecture" do %>
+    <%= prefecture.name %>
+  <% end %>
+<% end %>

--- a/app/views/shared/dashboard/_shop_info.html.erb
+++ b/app/views/shared/dashboard/_shop_info.html.erb
@@ -16,7 +16,7 @@
   <div class='dashbord-item'>住所[必須]</div><%= f.text_field :address %>
   <br>
   <div class='dashbord-item'>エリア[必須]</div>
-  <% Municipality.all.each do |municipalitie| %>
+  <% @municipalities.all.each do |municipalitie| %>
     <%= f.radio_button :municipalitie_id, municipalitie.id %>
     <%= f.label :municipalitie_id, municipalitie.name, {value: municipalitie.id, stylr: "display: inline-block;"} %>
   <% end %>

--- a/app/views/shared/dashboard/_shop_info.html.erb
+++ b/app/views/shared/dashboard/_shop_info.html.erb
@@ -17,8 +17,8 @@
   <br>
   <div class='dashbord-item'>エリア[必須]</div>
   <% Municipality.all.each do |municipalitie| %>
-    <%= f.radio_button :municipalitie, municipalitie.id %>
-    <%= f.label :municipalitie, municipalitie.name, {value: municipalitie.id, stylr: "display: inline-block;"} %>
+    <%= f.radio_button :municipalitie_id, municipalitie.id %>
+    <%= f.label :municipalitie_id, municipalitie.name, {value: municipalitie.id, stylr: "display: inline-block;"} %>
   <% end %>
   <br>
   <div class='dashbord-item'>定休日[必須]</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,10 @@ Rails.application.routes.draw do
   
   namespace :dashboard do
     resources :users, only: [:index, :destroy, :edit, :update]
-    resources :coffee_shops, except: [:show]
+    # resources :coffee_shops, except: [:show]
+    resources :coffee_shops do
+      get :select, on: :collection
+    end
     resources :search_categories, except: [:new]
     resources :prefectures, except: [:new]
     resources :municipalities, except: [:new]


### PR DESCRIPTION
-   関連issue
https://github.com/syota0402/cafe_de_niche/issues/53

# 背景
- この機能が必要な理由
エリアが増えてきて、探すのが手間になってきているため
あと前の修正で登録ができなくなっていた点を修正

- どういう機能なのか
新規登録の際にはまずは都道府県を選び、対象のエリアのみ表示する。
編集の際には、初回に選択された都道府県のエリアのみ表示する

- なぜこのPR単位なのか
エリア表示のみにまとめるため

# やったこと
## コードベース
- 設計方針
都道府県を選ぶためのページを追加して、
そこで都道府県を選択してから表示するように変更
以前はすべてのエリアが表示されていた

- model
特に変更なし

- controller
選択した都道府県のエリアのみ表示する処理を「new」「edit」に追加

- view
都道府県選択のための画面を追加

# 画面レイアウト
- 都道府県選択画面
![image](https://user-images.githubusercontent.com/87374457/154835578-bbe5e7c9-40ff-49fd-97f8-d08a0bec191e.png)

- 登録画面
![image](https://user-images.githubusercontent.com/87374457/154835580-6ce3f5f8-ec89-412b-b1ec-6d5dd899092c.png)

# 検証内容
- [x] 新規作成を押したときに全ての都道府県が表示されるか
- [x] 新規作成時に選択した都道府県のエリアのみ表示されているか
- [x] 選択したエリアで新規登録ができるか
- [x] 編集時に登録されているエリアと同都道府県のエリアのみ表示されているか
- [x] エリアの編集はできるか
- [x] 都道府県を追加しても表示されるか
- [x] エリアを追加しても表示されるか