### PR TITLE
検索項目に飲み物を追加

### DIFF
--- a/app/controllers/coffee_shops_controller.rb
+++ b/app/controllers/coffee_shops_controller.rb
@@ -61,6 +61,7 @@ class CoffeeShopsController < ApplicationController
       hash[:shop_seats_search_type] = params[:shop_seats_search_type]
       hash[:volume_in_shop_ids] = params[:volume_in_shop_ids]
       hash[:food_menu_ids] = params[:food_menu_ids]
+      hash[:drink_menu_ids] = params[:drink_menu_ids]
       hash[:shop_bgm_ids] = params[:shop_bgm_ids]
       hash[:pc_work] = params[:pc_work]
       hash[:time_limit] = params[:time_limit]

--- a/app/controllers/dashboard/coffee_shops_controller.rb
+++ b/app/controllers/dashboard/coffee_shops_controller.rb
@@ -62,7 +62,7 @@ class Dashboard::CoffeeShopsController < ApplicationController
   
   def coffee_shop_params
     params.require(:coffee_shop).permit(:name, :shop_url, :address, :shop_tell, :access, :business_start_hour, :business_end_hour, :instagram_url, :instagram_spot_url, :municipalitie_id, :slack_time_start, :slack_time_end, :age_group, :shop_seats, :pc_work, :time_limit, :terrace_seat, :can_reserved, :comic, :magazine, :latte_art, :newspaper, :morning_menu, :parking_place, :free_water, :with_pet, :free_pc, :shop_badget_upper, :shop_badget_lower, :coffee_price, :latte_price, :outlet, :wifi, :smoking, :reservation, :take_out, :with_children, :have_insta_account, :amusement, :look_by_instagram, :tell_secret, 
-    { :search_category_ids => [], :shop_atmosphere_ids => [], :coffee_bean_ids => [], :volume_in_shop_ids => [], :food_menu_ids => [], :shop_bgm_ids => [], :shop_scenery_ids => [], :payment_method_ids => [], :chair_type_ids => [], :use_scene_ids => [], :atmosphere_of_clerk_ids => [], :size_of_desk_ids => [], :point_card_ids => [] }, images: [])
+    { :search_category_ids => [], :shop_atmosphere_ids => [], :coffee_bean_ids => [], :volume_in_shop_ids => [], :food_menu_ids => [], :shop_bgm_ids => [], :shop_scenery_ids => [], :payment_method_ids => [], :chair_type_ids => [], :use_scene_ids => [], :atmosphere_of_clerk_ids => [], :size_of_desk_ids => [], :point_card_ids => [], :drink_menu_ids => [] }, images: [])
   end
   
   def check_user_authority

--- a/app/controllers/dashboard/drink_menus_controller.rb
+++ b/app/controllers/dashboard/drink_menus_controller.rb
@@ -1,0 +1,56 @@
+class Dashboard::DrinkMenusController < ApplicationController
+  before_action :set_drink_menu, only: %w[show edit update destroy]
+  before_action :check_user_authority, except: :index
+  layout "dashboard/dashboard"
+  
+  def index
+    @drink_menus = DrinkMenu.all
+    @drink_menu = DrinkMenu.new
+  end
+  
+  def create
+    @drink_menu = DrinkMenu.new(drink_menu_params)
+    if @drink_menu.save
+      redirect_to dashboard_drink_menus_path, notice: '登録完了'
+    else
+      flash[:alert] = @drink_menu.errors.full_messages
+      redirect_back(fallback_location: dashboard_drink_menus_path)
+    end
+  end
+  
+  def edit
+  end
+  
+  def update
+    if @drink_menu.update(drink_menu_params)
+      redirect_to dashboard_drink_menus_path, notice: '変更完了'
+    else
+      flash[:alert] = @drink_menu.errors.full_messages
+      redirect_back(fallback_location: dashboard_drink_menus_path)
+    end
+  end
+  
+  def destroy
+    @drink_menu.destroy
+    redirect_to dashboard_drink_menus_path
+  end
+  
+  private
+  
+  def set_drink_menu
+    @drink_menu = DrinkMenu.find(params[:id])
+  end
+  
+  def drink_menu_params
+    params.require(:drink_menu).permit(:name)
+  end
+  
+  def check_user_authority
+    @user = current_user
+    if @user.authority.eql?("2")
+      flash[:alert] = "権限がありません"
+      redirect_to dashboard_path
+    end
+  end
+  
+end

--- a/app/models/coffee_shop.rb
+++ b/app/models/coffee_shop.rb
@@ -40,6 +40,9 @@ class CoffeeShop < ApplicationRecord
 	has_many :coffee_shop_point_cards, dependent: :destroy
 	has_many :point_cards, :through => :coffee_shop_point_cards
 	
+	has_many :coffee_shop_drink_menus, dependent: :destroy
+	has_many :food_menus, :through => :coffee_shop_drink_menus
+	
 	accepts_nested_attributes_for :coffee_shop_search_categories, allow_destroy: true
 	accepts_nested_attributes_for :coffee_shop_shop_atmospheres, allow_destroy: true
 	accepts_nested_attributes_for :coffee_shop_coffee_beans, allow_destroy: true
@@ -53,6 +56,7 @@ class CoffeeShop < ApplicationRecord
 	accepts_nested_attributes_for :coffee_shop_atmosphere_of_clerks, allow_destroy: true
 	accepts_nested_attributes_for :coffee_shop_size_of_desks, allow_destroy: true
 	accepts_nested_attributes_for :coffee_shop_point_cards, allow_destroy: true
+	accepts_nested_attributes_for :coffee_shop_drink_menus, allow_destroy: true
 	acts_as_likeable
 	has_many_attached :images
 	

--- a/app/models/coffee_shop.rb
+++ b/app/models/coffee_shop.rb
@@ -41,7 +41,7 @@ class CoffeeShop < ApplicationRecord
 	has_many :point_cards, :through => :coffee_shop_point_cards
 	
 	has_many :coffee_shop_drink_menus, dependent: :destroy
-	has_many :food_menus, :through => :coffee_shop_drink_menus
+	has_many :drink_menus, :through => :coffee_shop_drink_menus
 	
 	accepts_nested_attributes_for :coffee_shop_search_categories, allow_destroy: true
 	accepts_nested_attributes_for :coffee_shop_shop_atmospheres, allow_destroy: true

--- a/app/models/coffee_shop_drink_menu.rb
+++ b/app/models/coffee_shop_drink_menu.rb
@@ -1,0 +1,2 @@
+class CoffeeShopDrinkMenu < ApplicationRecord
+end

--- a/app/models/coffee_shop_drink_menu.rb
+++ b/app/models/coffee_shop_drink_menu.rb
@@ -1,2 +1,4 @@
 class CoffeeShopDrinkMenu < ApplicationRecord
+  belongs_to :coffee_shop
+  belongs_to :drink_menu
 end

--- a/app/models/drink_menu.rb
+++ b/app/models/drink_menu.rb
@@ -1,0 +1,13 @@
+class DrinkMenu < ApplicationRecord
+  has_many :coffee_shop_drink_menus, dependent: :destroy
+  has_many :coffee_shops, :through => :coffee_shop_drink_menus
+  
+  #空白禁止
+  validates :name, presence: true
+  
+  # 重複禁止
+	validates :name, uniqueness: true
+	
+	# 文字数
+	validates :name, length: { maximum: 15}
+end

--- a/app/service/coffee_shop_search_service.rb
+++ b/app/service/coffee_shop_search_service.rb
@@ -57,6 +57,7 @@ class CoffeeShopSearchService
     @bookmark = hash[:bookmark]
     @bookmark_by_follower = hash[:bookmark_by_follower]
     @best_shop_by_follower = hash[:best_shop_by_follower]
+    @drink_menu_ids = hash[:drink_menu_ids]
   end
   
   def search
@@ -106,6 +107,9 @@ class CoffeeShopSearchService
     
     # 食べ物
     search_by_food_menu if @food_menu_ids.present?
+    
+    # 飲み物
+    search_by_drink_menu if @drink_menu_ids.present?
     
     # BGM
     search_by_shop_bgm if @shop_bgm_ids.present?
@@ -359,6 +363,12 @@ class CoffeeShopSearchService
   # 食べ物
   def search_by_food_menu
     coffee_shop_ids = CoffeeShopFoodMenu.where(food_menu_id: @food_menu_ids).pluck(:coffee_shop_id)
+    @coffee_shops = @coffee_shops.where(id: coffee_shop_ids)
+  end
+  
+  # 飲み物
+  def search_by_drink_menu
+    coffee_shop_ids = CoffeeShopDrinkMenu.where(drink_menu_id: @drink_menu_ids).pluck(:coffee_shop_id)
     @coffee_shops = @coffee_shops.where(id: coffee_shop_ids)
   end
   

--- a/app/service/coffee_shop_show_info_service.rb
+++ b/app/service/coffee_shop_show_info_service.rb
@@ -17,6 +17,7 @@ class CoffeeShopShowInfoService
     create_shop_seat if @coffee_shop.shop_seats.present?
     create_volume_in_shop if @coffee_shop.volume_in_shops.present?
     create_food_menu if @coffee_shop.food_menus.present?
+    create_drink_menu if @coffee_shop.drink_menus.present?
     create_shop_bgm if @coffee_shop.shop_bgms.present?
     create_pc_work if @coffee_shop.pc_work.present?
     create_time_limit if @coffee_shop.time_limit.present?
@@ -181,6 +182,15 @@ class CoffeeShopShowInfoService
     hash.class
     hash[:title] = '食べ物'
     hash[:value] = @coffee_shop.food_menus.pluck(:name).join(',')
+    @shop_info << hash
+  end
+  
+  # 飲み物
+  def create_drink_menu
+    hash = {}
+    hash.class
+    hash[:title] = '飲み物'
+    hash[:value] = @coffee_shop.drink_menus.pluck(:name).join(',')
     @shop_info << hash
   end
   

--- a/app/service/create_coffee_shop_search_conditions_service.rb
+++ b/app/service/create_coffee_shop_search_conditions_service.rb
@@ -18,6 +18,7 @@ class CreateCoffeeShopSearchConditionsService
     @shop_seats_search_type = hash[:shop_seats_search_type]
     @volume_in_shop_ids = hash[:volume_in_shop_ids]
     @food_menu_ids = hash[:food_menu_ids]
+    @drink_menu_ids = hash[:drink_menu_ids]
     @shop_bgm_ids = hash[:shop_bgm_ids]
     @pc_work = hash[:pc_work]
     @time_limit = hash[:time_limit]
@@ -75,6 +76,7 @@ class CreateCoffeeShopSearchConditionsService
     create_shop_seats if @shop_seats.present?
     create_volume_in_shop if @volume_in_shop_ids.present?
     create_food_menu if @food_menu_ids.present?
+    create_drink_menu if @drink_menu_ids.present?
     create_shop_bgm if @shop_bgm_ids.present?
     create_pc_work if @pc_work.present?
     create_time_limit if @time_limit.present?
@@ -186,6 +188,12 @@ class CreateCoffeeShopSearchConditionsService
   def create_food_menu
     food_menus = FoodMenu.where(id: @food_menu_ids)
     return_message = "食べ物：#{food_menus.pluck(:name).join('or')}"
+    @coffee_shop_search_conditions << return_message
+  end
+  
+  def create_drink_menu
+    drink_menus = DrinkMenu.where(id: @drink_menu_ids)
+    return_message = "飲み物：#{drink_menus.pluck(:name).join('or')}"
     @coffee_shop_search_conditions << return_message
   end
   

--- a/app/views/coffee_shops/show.html.erb
+++ b/app/views/coffee_shops/show.html.erb
@@ -31,24 +31,26 @@
   		<% end %>
   	</tbody>
   </table>
-  <div class="liker-container">
-  	<div class="liker-title">
-  		お気に入り
-  	</div>
-  	<div class="liker-count">
-  		<%= @coffee_shop.likers_count %>人
-  	</div>
-	  <% @likers.last(5).each do |liker| %>
-	  	<div class="liker-user">
-	  		<%= link_to(user_path(liker.id)) do %>
-	  			<%= render partial: 'shared/show_image', locals: { target: liker, image_size: "50x50" } %>
-	  			<p>
-	  				<%= liker.name %>
-	  			</p>
-				<% end %>
-			</div>
-	  <% end %>
-  </div>
+  <% if @likers.present? %>
+	  <div class="liker-container">
+	  	<div class="liker-title">
+	  		お気に入り
+	  	</div>
+	  	<div class="liker-count">
+	  		<%= @coffee_shop.likers_count %>人
+	  	</div>
+		  <% @likers.last(5).each do |liker| %>
+		  	<div class="liker-user">
+		  		<%= link_to(user_path(liker.id)) do %>
+		  			<%= render partial: 'shared/show_image', locals: { target: liker, image_size: "50x50" } %>
+		  			<p>
+		  				<%= liker.name %>
+		  			</p>
+					<% end %>
+				</div>
+		  <% end %>
+		</div>
+	<% end %>
 	<div class="review-totel-container">
 		<div class="review">Review</div>
 		<div class="review-totel-count">

--- a/app/views/dashboard/drink_menus/edit.html.erb
+++ b/app/views/dashboard/drink_menus/edit.html.erb
@@ -1,0 +1,9 @@
+<h1>飲み物編集</h1>
+
+<%= form_with model: @drink_menu, url: dashboard_drink_menu_path(@drink_menu), local: true do |f| %>
+  <%= f.label :name, "品面" %>
+  <%= f.text_field :name %>
+  
+  <%= f.submit "更新" %>
+<% end %>
+<%= link_to "飲み物一覧に戻る", dashboard_drink_menus_path %>

--- a/app/views/dashboard/drink_menus/index.html.erb
+++ b/app/views/dashboard/drink_menus/index.html.erb
@@ -1,0 +1,3 @@
+<%= render partial: 'shared/dashboard/search_items_index', locals: 
+{ item_name: '品名', search_item: @drink_menu, search_items_path: dashboard_drink_menus_path,
+search_items: @drink_menus, items: 'drink_menus', itemp: 'drink_menu' } %>

--- a/app/views/layouts/dashboard/_sidebar.html.erb
+++ b/app/views/layouts/dashboard/_sidebar.html.erb
@@ -38,4 +38,6 @@
     <%= link_to "机の広さ一覧", dashboard_size_of_desks_path %>
   <br>
     <%= link_to "ポイントカード一覧", dashboard_point_cards_path %>
+  <br>
+    <%= link_to "飲み物一覧", dashboard_drink_menus_path %>
 </div>

--- a/app/views/shared/dashboard/_shop_info.html.erb
+++ b/app/views/shared/dashboard/_shop_info.html.erb
@@ -91,6 +91,12 @@
       <%= food_menu.label { food_menu.check_box + food_menu.text } %>
     <% end %>
   </div>
+  <div class='dashbord-item'>飲み物</div>
+  <div class="check_box">
+    <%= f.collection_check_boxes(:drink_menu_ids, DrinkMenu.all, :id, :name) do |drink_menu| %>
+      <%= drink_menu.label { drink_menu.check_box + drink_menu.text } %>
+    <% end %>
+  </div>
   <div class='dashbord-item'>BGM</div>
   <div class="check_box">
     <%= f.collection_check_boxes(:shop_bgm_ids, ShopBgm.all, :id, :name) do |shop_bgm| %>

--- a/app/views/web/index.html.erb
+++ b/app/views/web/index.html.erb
@@ -12,39 +12,45 @@
       <% end %>
     <% end %>
     
-    <div class="user-favorite-container">
-      <%= link_to(favorite_users_path) do %>
-        <span class="user-favorite-title">お気に入りのカフェ</span>
-      <% end %>
-      <% current_user.likees(CoffeeShop).last(5).each do |favorite_coffee_shop| %>
-        <div class="liker-user">
-          <%= link_to(coffee_shop_path(favorite_coffee_shop)) do %>
-		  			<%= render partial: 'shared/show_image_first', locals: { target: favorite_coffee_shop, image_size: "50x50" } %>
-		  			<p>
-		  				<%= favorite_coffee_shop.name %>
-		  			</p>
-					<% end %>
-        </div>
-      <% end %>
-    </div>
+    <!--お気に入りのお店を5つ表示-->
+    <% if current_user.likees(CoffeeShop).present? %>
+      <div class="user-favorite-container">
+        <%= link_to(favorite_users_path) do %>
+          <span class="user-favorite-title">お気に入りのカフェ</span>
+        <% end %>
+        <% current_user.likees(CoffeeShop).last(5).each do |favorite_coffee_shop| %>
+          <div class="liker-user">
+            <%= link_to(coffee_shop_path(favorite_coffee_shop)) do %>
+  		  			<%= render partial: 'shared/show_image_first', locals: { target: favorite_coffee_shop, image_size: "50x50" } %>
+  		  			<p>
+  		  				<%= favorite_coffee_shop.name %>
+  		  			</p>
+  					<% end %>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
     
     <br>
     
-    <div class="user-favorite-container">
-      <%= link_to(following_users_path) do %>
-        <span class="user-favorite-title">フォローしているユーザー</span>
-      <% end %>
-      <% current_user.followees(User).last(5).each do |follow_user| %>
-        <div class="liker-user">
-          <%= link_to(user_path(follow_user.id)) do %>
-		  			<%= render partial: 'shared/show_image', locals: { target: follow_user, image_size: "50x50" } %>
-		  			<p>
-		  				<%= follow_user.name %>
-		  			</p>
-					<% end %>
-        </div>
-      <% end %>
-    </div>
+    <!--フォローユーザーを5人表示-->
+    <% if current_user.followees(User).present? %>
+      <div class="user-favorite-container">
+        <%= link_to(following_users_path) do %>
+          <span class="user-favorite-title">フォローしているユーザー</span>
+        <% end %>
+        <% current_user.followees(User).last(5).each do |follow_user| %>
+          <div class="liker-user">
+            <%= link_to(user_path(follow_user.id)) do %>
+  		  			<%= render partial: 'shared/show_image', locals: { target: follow_user, image_size: "50x50" } %>
+  		  			<p>
+  		  				<%= follow_user.name %>
+  		  			</p>
+  					<% end %>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
     
   <!--サインインしていない-->
   <% else %>

--- a/app/views/web/search.html.erb
+++ b/app/views/web/search.html.erb
@@ -154,6 +154,18 @@
   </div>
   
   <div class="search-container">
+    <a class="search-name" href="#fold-drink" data-toggle="collapse">飲み物</a>
+    <div id="fold-drink" class="collapse">
+      <%= f.collection_check_boxes(:drink_menu_ids, DrinkMenu.all, :id, :name, {include_hidden: false}) do |drink_menu| %>
+        <div class="search-checkbox">
+          <%= drink_menu.check_box %>
+          <%= drink_menu.label %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+  
+  <div class="search-container">
     <a class="search-name" href="#fold-shop-bgm" data-toggle="collapse">BGM</a>
     <div id="fold-shop-bgm" class="collapse">
       <%= f.collection_check_boxes(:shop_bgm_ids, ShopBgm.all, :id, :name, {include_hidden: false}) do |shop_bgm| %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,7 @@ Rails.application.routes.draw do
     resources :atmosphere_of_clerks, except: [:new]
     resources :size_of_desks, except: [:new]
     resources :point_cards, except: [:new]
+    resources :drink_menus, except: [:new]
   end
   
   devise_for :users, :controllers => {

--- a/db/migrate/20220226092448_create_drink_menus.rb
+++ b/db/migrate/20220226092448_create_drink_menus.rb
@@ -1,0 +1,9 @@
+class CreateDrinkMenus < ActiveRecord::Migration[5.2]
+  def change
+    create_table :drink_menus do |t|
+      t.string :name
+      
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220226092503_create_coffee_shop_drink_menus.rb
+++ b/db/migrate/20220226092503_create_coffee_shop_drink_menus.rb
@@ -1,0 +1,10 @@
+class CreateCoffeeShopDrinkMenus < ActiveRecord::Migration[5.2]
+  def change
+    create_table :coffee_shop_drink_menus do |t|
+      t.integer :coffee_shop_id
+      t.integer :drink_menu_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_08_110634) do
+ActiveRecord::Schema.define(version: 2022_02_26_092503) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -74,6 +74,13 @@ ActiveRecord::Schema.define(version: 2022_02_08_110634) do
   create_table "coffee_shop_coffee_beans", force: :cascade do |t|
     t.integer "coffee_shop_id"
     t.integer "coffee_bean_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "coffee_shop_drink_menus", force: :cascade do |t|
+    t.integer "coffee_shop_id"
+    t.integer "drink_menu_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
@@ -202,6 +209,12 @@ ActiveRecord::Schema.define(version: 2022_02_08_110634) do
   end
 
   create_table "day_of_weeks", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "drink_menus", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/test/fixtures/coffee_shop_drink_menus.yml
+++ b/test/fixtures/coffee_shop_drink_menus.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/drink_menus.yml
+++ b/test/fixtures/drink_menus.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/coffee_shop_drink_menu_test.rb
+++ b/test/models/coffee_shop_drink_menu_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class CoffeeShopDrinkMenuTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/drink_menu_test.rb
+++ b/test/models/drink_menu_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class DrinkMenuTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# 背景
- この機能が必要な理由
飲み物のメニューが何があるかで、検索できるようにするため

- どういう機能なのか
店舗情報に飲み物を追加して、飲み物でも検索できるようにする

- なぜこのPR単位なのか
飲み物でまとめるため

# やったこと
## コードベース
- 設計方針
飲み物は種類を増やせるように中間テーブルを用いて作成する
飲み物の追加は管理画面から行う

- model
飲み物テーブル<drink_menu>と店舗情報と紐づけるための中間テーブルを作成

- controller
食べ物とほぼ同じように作成

- view
管理者画面に飲み物を追加するための画面を追加

# 画面レイアウト
- 飲み物管理画面
![image](https://user-images.githubusercontent.com/87374457/155867427-14c6a751-3954-4985-8140-676c7666a47b.png)

- 店舗情報入力画面
![image](https://user-images.githubusercontent.com/87374457/155867433-ef47654e-28c3-4196-8af1-552c9eb72a68.png)

- 検索画面
![image](https://user-images.githubusercontent.com/87374457/155867451-af0f52fc-d997-48d2-affe-97f3a9c7a03f.png)

# 検証内容
- [x] 飲み物が登録できるか
- [x] 飲み物の名称を変更できるか
- [x] 飲み物を削除できるか
- [x] 飲み物を店舗情報に登録できるか
- [x] 店舗情報に登録され等飲み物を変更できるか
- [x] 飲み物から店舗の検索ができるか
- [x] 店舗情報に飲み物が表示されているか

# 関連issue
https://github.com/syota0402/cafe_de_niche/issues/63

https://github.com/syota0402/cafe_de_niche/issues/59
こっそり修正