### PR TITLE
エリア一覧に検索機能を追加

### DIFF
--- a/app/controllers/dashboard/municipalities_controller.rb
+++ b/app/controllers/dashboard/municipalities_controller.rb
@@ -5,7 +5,13 @@ class Dashboard::MunicipalitiesController < ApplicationController
   layout "dashboard/dashboard"
   
   def index
-    @municipalities = Municipality.all
+    # @municipalities = Municipality.all
+    if params[:keyword].present?
+      keyword = params[:keyword].strip
+      @municipalities = Municipality.search_for_eria_name(keyword).page(params[:page]).per(15)
+    else
+      @municipalities = Municipality.page(params[:page]).per(15)
+    end
     @municipality = Municipality.new
   end
   

--- a/app/models/municipality.rb
+++ b/app/models/municipality.rb
@@ -2,4 +2,9 @@ class Municipality < ApplicationRecord
   belongs_to :prefecture
   
   validates :name, :prefecture_id, presence: true
+  
+  scope :search_for_eria_name, -> (keyword) {
+    where("name LIKE ?", "%#{keyword}%")
+  }
+  
 end

--- a/app/service/coffee_shop_search_service.rb
+++ b/app/service/coffee_shop_search_service.rb
@@ -17,6 +17,7 @@ class CoffeeShopSearchService
     @shop_atmosphere_ids = hash[:shop_atmosphere_ids]
     @shop_seats = hash[:shop_seats]
     @shop_seats_search_type = hash[:shop_seats_search_type]
+    @coffee_bean_ids = hash[:coffee_bean_ids]
     @volume_in_shop_ids = hash[:volume_in_shop_ids]
     @food_menu_ids = hash[:food_menu_ids]
     @shop_bgm_ids = hash[:shop_bgm_ids]

--- a/app/service/create_coffee_shop_search_conditions_service.rb
+++ b/app/service/create_coffee_shop_search_conditions_service.rb
@@ -16,6 +16,7 @@ class CreateCoffeeShopSearchConditionsService
     @shop_atmosphere_ids = hash[:shop_atmosphere_ids]
     @shop_seats = hash[:shop_seats]
     @shop_seats_search_type = hash[:shop_seats_search_type]
+    @coffee_bean_ids = hash[:coffee_bean_ids]
     @volume_in_shop_ids = hash[:volume_in_shop_ids]
     @food_menu_ids = hash[:food_menu_ids]
     @drink_menu_ids = hash[:drink_menu_ids]
@@ -74,6 +75,7 @@ class CreateCoffeeShopSearchConditionsService
     create_age_group if @age_group.present?
     create_shop_atmosphere if @shop_atmosphere_ids.present?
     create_shop_seats if @shop_seats.present?
+    create_coffee_bean if @coffee_bean_ids.present?
     create_volume_in_shop if @volume_in_shop_ids.present?
     create_food_menu if @food_menu_ids.present?
     create_drink_menu if @drink_menu_ids.present?
@@ -168,8 +170,9 @@ class CreateCoffeeShopSearchConditionsService
     @coffee_shop_search_conditions << return_message
   end
   
+  # 珈琲豆の種類
   def create_coffee_bean
-    coffee_beans = CoffeeBean.where(id: params[:coffee_bean_ids])
+    coffee_beans = CoffeeBean.where(id: @coffee_bean_ids)
     return_message = "コーヒー豆：#{coffee_beans.pluck(:name).join('or')}"
     @coffee_shop_search_conditions << return_message
   end

--- a/app/views/dashboard/municipalities/index.html.erb
+++ b/app/views/dashboard/municipalities/index.html.erb
@@ -11,6 +11,12 @@
     <%= f.submit "新規作成" %>
   <% end %>
   
+  <%= form_with url: dashboard_municipalities_path, method: :get, local: true do |f| %>
+    エリア検索
+    <%= f.text_field :keyword %>
+    <%= f.submit "検索" %>
+  <% end %>
+  
   <table class="table mt-5">
     <thead>
       <tr>
@@ -38,4 +44,5 @@
       <% end %>
     </tbody>
   </table>
+  <%= paginate @municipalities %>
 </div>


### PR DESCRIPTION
# 背景
- この機能が必要な理由
エリアが多くなってきて、すでに作成したエリアかどうかわからなくなるから

- どういう機能なのか
エリア一覧の画面上で検索ができるようにして、すぐに作成されているかどうかを判断できる

- なぜこのPR単位なのか
エリア一覧の機能追加だけでまとめるため

# やったこと
## コードベース
- 設計方針
画面追加と同じように検索を作成する
簡単な機能なので、新しい画面は追加せず既存の画面内で完結させる

- model
エリアに検索機能の追加

- controller
キーワードを基に検索結果のみを渡すように修正

- view
新規の下に検索ボタンを作成
数が多くなってきたので、ページネーションも追加

# 画面レイアウト
- エリア一覧
![image](https://user-images.githubusercontent.com/87374457/167292797-a4a43496-7e45-4d17-968d-221404722465.png)

# 検証内容
- [x] 初回表示の時はすべて表示されているか
- [x] 検索結果のみ表示されているか
- [x] 検索後も空白で検索すれば再度検索ができるか

# 関連issue
https://github.com/syota0402/cafe_de_niche/issues/71