### PR TITLE
登録数を表示できるように変更

### DIFF
--- a/app/views/web/index.html.erb
+++ b/app/views/web/index.html.erb
@@ -112,7 +112,7 @@
   <br>
   <% Prefecture.all.each do |prefecture| %>
     <b><%= prefecture.name %></b>
-    <% Municipality.where(prefecture_id: prefecture.id).limit(5).each do |municipality| %>
+    <% Municipality.where(prefecture_id: prefecture.id).each do |municipality| %>
       <%= municipality.name %>：<%= CoffeeShop.where(municipalitie_id: municipality.id).count %>件
     <% end %>
     <br>

--- a/app/views/web/index.html.erb
+++ b/app/views/web/index.html.erb
@@ -107,7 +107,17 @@
     <%= link_to search_path(prefecture_id: prefecture.id) , class: "btn btn-prefecture" do %>
       <%= prefecture.name %>
     <% end %>
+    
   <% end %>
+  <br>
+  <% Prefecture.all.each do |prefecture| %>
+    <b><%= prefecture.name %></b>
+    <% Municipality.where(prefecture_id: prefecture.id).limit(5).each do |municipality| %>
+      <%= municipality.name %>：<%= CoffeeShop.where(municipalitie_id: municipality.id).count %>件
+    <% end %>
+    <br>
+  <% end %>
+  
 </div>
 
 <hr>


### PR DESCRIPTION
 # 背景
- この機能が必要な理由
お店がどの地域にどのぐらい登録されているかをわかるようにするため

- どういう機能なのか
登録されているお店の数をトップページにどの地域が何件か表示する

- なぜこのPR単位なのか
表示する機能だけでまとめるため

# やったこと
## コードベース
- 設計方針
Viewのみの修正で実装を行う
どの地域が検索項目にあるかもわかるように全て表示する

- model
変更なし

- controller
変更なし

- view
トップページに表示するように変更

# 画面レイアウト
- トップページ
![image](https://user-images.githubusercontent.com/87374457/179447837-89d47b1c-e687-45a5-880c-2a3826973b78.png)

# 検証内容
- [x] 都道府県は表示できるか
- [x] 地域は表示されているか
- [x] 地域に登録されている店舗数は表示されているか
- [x] 店舗の登録がない地域でも表示できているか

# 関連issue
なし